### PR TITLE
docs: Dockerコマンドを'frontend'に統一＋exec運用へ変更／Prettier整形

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Conversation Guidelines
 
 - 常に日本語で会話する
+- コミットメッセージおよびPR（タイトル・説明）は日本語で記載する
 
 ## Development Methodology
 
@@ -77,9 +78,9 @@
 - `npm run test:e2e:ui` - E2EテストをUI付きで実行
 
 #### Frontend Development
-- `docker compose up -d app` - Start containerized development server on localhost:5173
-- `docker compose build --no-cache app` - Rebuild with new dependencies
-- `docker compose logs -f app` - View application logs
+- `docker compose up -d frontend` - Start containerized development server on localhost:5173
+- `docker compose build --no-cache frontend` - Rebuild with new dependencies
+- `docker compose logs -f frontend` - View application logs
 
 #### Backend Development
 - `docker compose up -d backend mysql` - Start Rails API server on localhost:3001
@@ -94,24 +95,23 @@
 
 ### Docker Testing
 
-#### Frontend Testing
-- `docker compose --profile test run --rm test` - Run Vitest unit tests once
-- `docker compose run --rm app npm run test` - Run unit tests in watch mode
-- `docker compose --profile e2e run --rm e2e` - Run Playwright E2E tests (requires app running)
-- `docker compose run --rm app npm run test:e2e:ui` - Run E2E tests with UI mode
+#### Frontend Testing（既存コンテナでexec実行）
+- `docker compose exec frontend npm run test:run` - Run Vitest unit tests once
+- `docker compose exec frontend npm run test` - Run unit tests in watch mode
+- E2E（ローカル実行推奨）: `npm run test:e2e` / `npm run test:e2e:ui`（要アプリ起動）
 
-#### Backend Testing
-- `docker compose run --rm backend rails test` - Run all Rails tests
-- `docker compose run --rm backend rails test --verbose` - Run Rails tests with detailed output
-- `docker compose run --rm backend rails test test/models/` - Run only model tests
-- `docker compose run --rm backend rails db:test:prepare` - Prepare test database
+#### Backend Testing（既存コンテナでexec実行）
+- `docker compose exec backend rails test` - Run all Rails tests
+- `docker compose exec backend rails test --verbose` - Detailed output
+- `docker compose exec backend rails test test/models/` - Run only model tests
+- `docker compose exec backend rails db:test:prepare` - Prepare test database
 
-### Docker Code Quality
+### Docker Code Quality（既存コンテナでexec実行）
 
-- `docker compose run --rm app npm run lint` - Run ESLint to check code quality
-- `docker compose run --rm app npm run lint:fix` - Run ESLint with auto-fix
-- `docker compose run --rm app npm run format` - Format code with Prettier
-- `docker compose run --rm app npm run format:check` - Check code formatting
+- `docker compose exec frontend npm run lint` - Run ESLint to check code quality
+- `docker compose exec frontend npm run lint:fix` - Run ESLint with auto-fix
+- `docker compose exec frontend npm run format` - Format code with Prettier
+- `docker compose exec frontend npm run format:check` - Check code formatting
 
 ### Local Development（非推奨）
 
@@ -328,3 +328,12 @@ it('displays all categories with names', () => {
 - Vite handles both development and production builds
 - TypeScript compilation happens before Vite build in production
 - Source maps enabled for debugging in all environments
+
+### Commit / PR ガイドライン
+
+- 言語: コミットメッセージ、PRタイトル・説明は日本語で記載する
+- コミットメッセージの構成（推奨）:
+  - 1行目: 要約（例: "docs: Dockerコマンドをfrontendに統一"）
+  - 本文: 変更理由・詳細・影響範囲（箇条書き可）
+- PR説明の構成（推奨）:
+  - 概要 / 変更点 / 背景・目的 / 注意点（破壊的変更があれば明記）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Conversation Guidelines
 
 - 常に日本語で会話する
+- コミットメッセージおよびPR（タイトル・説明）は日本語で記載する
 
 ## Development Methodology
 
@@ -79,9 +80,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run test:e2e:ui` - E2EテストをUI付きで実行
 
 #### Frontend Development
-- `docker compose up -d app` - Start containerized development server on localhost:5173
-- `docker compose build --no-cache app` - Rebuild with new dependencies
-- `docker compose logs -f app` - View application logs
+- `docker compose up -d frontend` - Start containerized development server on localhost:5173
+- `docker compose build --no-cache frontend` - Rebuild with new dependencies
+- `docker compose logs -f frontend` - View application logs
 
 #### Backend Development
 - `docker compose up -d backend mysql` - Start Rails API server on localhost:3001
@@ -96,24 +97,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Docker Testing
 
-#### Frontend Testing
-- `docker compose --profile test run --rm test` - Run Vitest unit tests once
-- `docker compose run --rm app npm run test` - Run unit tests in watch mode
-- `docker compose --profile e2e run --rm e2e` - Run Playwright E2E tests (requires app running)
-- `docker compose run --rm app npm run test:e2e:ui` - Run E2E tests with UI mode
+#### Frontend Testing（既存コンテナでexec実行）
+- `docker compose exec frontend npm run test:run` - Run Vitest unit tests once
+- `docker compose exec frontend npm run test` - Run unit tests in watch mode
+- E2E（ローカル実行推奨）: `npm run test:e2e` / `npm run test:e2e:ui`（要アプリ起動）
 
-#### Backend Testing
-- `docker compose run --rm backend rails test` - Run all Rails tests
-- `docker compose run --rm backend rails test --verbose` - Run Rails tests with detailed output
-- `docker compose run --rm backend rails test test/models/` - Run only model tests
-- `docker compose run --rm backend rails db:test:prepare` - Prepare test database
+#### Backend Testing（既存コンテナでexec実行）
+- `docker compose exec backend rails test` - Run all Rails tests
+- `docker compose exec backend rails test --verbose` - Run Rails tests with detailed output
+- `docker compose exec backend rails test test/models/` - Run only model tests
+- `docker compose exec backend rails db:test:prepare` - Prepare test database
 
-### Docker Code Quality
+### Docker Code Quality（既存コンテナでexec実行）
 
-- `docker compose run --rm app npm run lint` - Run ESLint to check code quality
-- `docker compose run --rm app npm run lint:fix` - Run ESLint with auto-fix
-- `docker compose run --rm app npm run format` - Format code with Prettier
-- `docker compose run --rm app npm run format:check` - Check code formatting
+- `docker compose exec frontend npm run lint` - Run ESLint to check code quality
+- `docker compose exec frontend npm run lint:fix` - Run ESLint with auto-fix
+- `docker compose exec frontend npm run format` - Format code with Prettier
+- `docker compose exec frontend npm run format:check` - Check code formatting
+
+### Commit / PR ガイドライン
+
+- 言語: コミットメッセージ、PRタイトル・説明は日本語で記載する
+- コミットメッセージの構成（推奨）:
+  - 1行目: 要約（例: "docs: Dockerコマンドをfrontendに統一"）
+  - 本文: 変更理由・詳細・影響範囲（箇条書き可）
+- PR説明の構成（推奨）:
+  - 概要 / 変更点 / 背景・目的 / 注意点（破壊的変更があれば明記）
 
 ### Local Development（非推奨）
 

--- a/Docker.md
+++ b/Docker.md
@@ -15,7 +15,7 @@
 
 ```bash
 # フロントエンドのみ起動
-docker compose up -d app
+docker compose up -d frontend
 
 # フロントエンド + バックエンド + MySQL の起動
 docker compose up -d
@@ -30,7 +30,7 @@ docker compose up -d backend mysql
 
 ```bash
 # フロントエンドのログを確認
-docker compose up app
+docker compose up frontend
 
 # 全サービスのログを確認
 docker compose up
@@ -66,7 +66,7 @@ docker compose up
 docker compose logs
 
 # フロントエンドのログを表示
-docker compose logs app
+docker compose logs frontend
 
 # バックエンドのログを表示
 docker compose logs backend
@@ -75,7 +75,7 @@ docker compose logs backend
 docker compose logs mysql
 
 # リアルタイムでログを追跡
-docker compose logs -f app
+docker compose logs -f frontend
 docker compose logs -f backend
 ```
 
@@ -90,7 +90,7 @@ docker compose down
 ### 特定のサービスのみを停止
 
 ```bash
-docker compose stop app
+docker compose stop frontend
 ```
 
 ### フォアグラウンドで動作している場合
@@ -102,7 +102,7 @@ docker compose stop app
 ### アプリケーションの再起動
 
 ```bash
-docker compose restart app
+docker compose restart frontend
 ```
 
 ### コンテナの状態確認
@@ -116,14 +116,14 @@ docker compose ps
 ソースコードを変更してDockerfileやpackage.jsonを更新した場合：
 
 ```bash
-docker compose build app
-docker compose up -d app
+docker compose build frontend
+docker compose up -d frontend
 ```
 
 または、ビルドと起動を同時に実行：
 
 ```bash
-docker compose up -d --build app
+docker compose up -d --build frontend
 ```
 
 ### 依存関係を追加した場合の完全再ビルド
@@ -132,15 +132,15 @@ docker compose up -d --build app
 
 ```bash
 # キャッシュを無効にして完全再ビルド
-docker compose build --no-cache app
-docker compose up -d app
+docker compose build --no-cache frontend
+docker compose up -d frontend
 ```
 
 または、コンテナとボリュームを削除してから再ビルド：
 
 ```bash
 docker compose down -v
-docker compose up -d --build app
+docker compose up -d --build frontend
 ```
 
 ### コンテナとボリュームの完全削除
@@ -155,17 +155,17 @@ docker compose down -v
 
 1. **初回起動**:
    ```bash
-   docker compose up -d --build app
+docker compose up -d --build
    ```
 
 2. **日常的な起動**:
    ```bash
-   docker compose up -d app
+docker compose up -d
    ```
 
 3. **ログ確認**:
    ```bash
-   docker compose logs -f app
+docker compose logs -f
    ```
 
 4. **停止**:
@@ -181,27 +181,27 @@ docker compose down -v
 
 ```yaml
 services:
-  app:
+  frontend:
     ports:
-      - "3000:5173"  # ホストの3000番ポートにマッピング
+      - "9000:5173"  # ホストの9000番ポートにマッピング
 ```
 
 ### コンテナが起動しない場合
 
 1. ログを確認：
    ```bash
-   docker compose logs app
+   docker compose logs
    ```
 
 2. コンテナを再ビルド：
    ```bash
-   docker compose build --no-cache app
+   docker compose build --no-cache
    ```
 
 3. 完全にクリーンアップしてから再起動：
    ```bash
    docker compose down -v
-   docker compose up -d --build app
+   docker compose up -d --build
    ```
 
 ## テストの実行
@@ -210,17 +210,16 @@ services:
 
 #### 単体テスト（Unit Tests）
 
-Vitestを使用した単体テストをDockerコンテナ内で実行：
+Vitestを既存のfrontendコンテナでexec実行：
 
 ```bash
-# 単体テストを一度だけ実行
-docker compose --profile test run --rm test
+# 既にfrontendが起動している前提（未起動なら: docker compose up -d frontend）
 
-# または、直接コマンドを指定して実行
-docker compose run --rm app npm run test:run
+# 単体テストを一度だけ実行
+docker compose exec frontend npm run test:run
 
 # ウォッチモードでテスト実行
-docker compose run --rm app npm run test
+docker compose exec frontend npm run test
 ```
 
 #### E2Eテスト（End-to-End Tests）
@@ -277,10 +276,10 @@ docker compose run --rm backend rails db:migrate RAILS_ENV=test
 1. **フロントエンド開発中の継続的テスト**:
    ```bash
    # アプリケーション起動
-   docker compose up -d app
+   docker compose up -d frontend
    
-   # 単体テストを監視モードで実行
-   docker compose run --rm app npm run test
+   # 単体テストを監視モードで実行（既存コンテナでexec）
+   docker compose exec frontend npm run test
    ```
 
 2. **バックエンド開発中の継続的テスト**:
@@ -297,11 +296,11 @@ docker compose run --rm backend rails db:migrate RAILS_ENV=test
    # 全サービス起動
    docker compose up -d
    
-   # バックエンドテスト実行
-   docker compose run --rm backend rails test
+   # バックエンドテスト実行（既存コンテナでexec）
+   docker compose exec backend rails test
    
-   # フロントエンド単体テスト実行
-   docker compose run --rm app npm run test:run
+   # フロントエンド単体テスト実行（既存コンテナでexec）
+   docker compose exec frontend npm run test:run
    
    # E2Eテストをローカルで実行（別のターミナル）
    npm run test:e2e
@@ -313,11 +312,11 @@ docker compose run --rm backend rails db:migrate RAILS_ENV=test
    docker compose build --no-cache
    docker compose up -d
    
-   # バックエンドテスト
-   docker compose run --rm backend rails test
+   # バックエンドテスト（既存コンテナでexec）
+   docker compose exec backend rails test
    
-   # フロントエンドテスト
-   docker compose --profile test run --rm test
+   # フロントエンドテスト（既存コンテナでexec）
+   docker compose exec frontend npm run test:run
    
    # E2Eテスト（別途ローカル環境）
    npm run test:e2e
@@ -330,7 +329,7 @@ docker compose run --rm backend rails db:migrate RAILS_ENV=test
 
 1. アプリケーションが完全に起動していることを確認：
    ```bash
-   docker compose logs app
+   docker compose logs frontend
    curl http://localhost:5173
    ```
 
@@ -348,8 +347,8 @@ docker compose run --rm backend rails db:migrate RAILS_ENV=test
 
 依存関係を再インストール：
 ```bash
-docker compose build --no-cache app
-docker compose --profile test run --rm test
+docker compose build --no-cache frontend
+docker compose exec frontend npm run test:run
 ```
 
 ## Rails 開発コマンド

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React Todo App
+# Todo App
 
 React + TypeScript + Vite のフロントエンドと Ruby on Rails API のバックエンドで構築されたフルスタックTodoアプリケーションです。カテゴリ管理、フィルタリング、ダークモード対応などの機能を持ちます。
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ bin/rails server
 ### フロントエンドテスト
 ```bash
 # 単体テスト
-docker compose --profile test run --rm test
+docker compose exec frontend npm run test:run
 
 # E2Eテスト（アプリ起動後）
 npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ todo-app/
 
 ```bash
 # フロントエンドのみ起動
-docker compose up -d app
+docker compose up -d frontend
 
 # フルスタック起動（フロントエンド + バックエンド + MySQL）
 docker compose up -d

--- a/frontend/__tests__/App.test.tsx
+++ b/frontend/__tests__/App.test.tsx
@@ -1,150 +1,150 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { MemoryRouter } from 'react-router-dom'
-import App from '../src/App'
-import { useDarkMode } from '../src/hooks/useDarkMode'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import App from "../src/App";
+import { useDarkMode } from "../src/hooks/useDarkMode";
 
 // useDarkModeフックをモック
-vi.mock('../src/hooks/useDarkMode')
+vi.mock("../src/hooks/useDarkMode");
 
-const mockUseDarkMode = vi.mocked(useDarkMode)
+const mockUseDarkMode = vi.mocked(useDarkMode);
 
-describe('App Router', () => {
+describe("App Router", () => {
   beforeEach(() => {
     mockUseDarkMode.mockReturnValue({
       isDarkMode: false,
       toggleDarkMode: vi.fn(),
       setDarkMode: vi.fn(),
-    })
-  })
+    });
+  });
   // 概要: ルートパスでTodoアプリが表示されることをテスト
   // 目的: / ルートが正しくTodoAppコンポーネントを表示することを保証
-  it('renders TodoApp at root path', () => {
+  it("renders TodoApp at root path", () => {
     render(
       <MemoryRouter
-        initialEntries={['/']}
+        initialEntries={["/"]}
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <App />
-      </MemoryRouter>
-    )
+      </MemoryRouter>,
+    );
 
     // TodoAppの特徴的な要素が表示されることを確認
-    expect(screen.getByText('Todo App')).toBeInTheDocument()
+    expect(screen.getByText("Todo App")).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText('新しいタスクを入力')
-    ).toBeInTheDocument()
-  })
+      screen.getByPlaceholderText("新しいタスクを入力"),
+    ).toBeInTheDocument();
+  });
 
   // 概要: /categoriesパスでカテゴリページが表示されることをテスト
   // 目的: /categoriesルートが正しくCategoriesPageコンポーネントを表示することを保証
-  it('renders CategoriesPage at /categories path', () => {
+  it("renders CategoriesPage at /categories path", () => {
     render(
       <MemoryRouter
-        initialEntries={['/categories']}
+        initialEntries={["/categories"]}
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <App />
-      </MemoryRouter>
-    )
+      </MemoryRouter>,
+    );
 
     // カテゴリページが表示されることを確認（ナビゲーション以外で）
-    const allCategoryTexts = screen.getAllByText('カテゴリ管理')
-    expect(allCategoryTexts.length).toBeGreaterThanOrEqual(2) // ナビとメインコンテンツ
-  })
+    const allCategoryTexts = screen.getAllByText("カテゴリ管理");
+    expect(allCategoryTexts.length).toBeGreaterThanOrEqual(2); // ナビとメインコンテンツ
+  });
 
   // 概要: /categories/newパスでカテゴリ新規作成フォームが表示されることをテスト
   // 目的: /categories/newルートが正しくCategoryFormコンポーネントを表示することを保証
-  it('renders CategoryForm at /categories/new path', () => {
+  it("renders CategoryForm at /categories/new path", () => {
     render(
       <MemoryRouter
-        initialEntries={['/categories/new']}
+        initialEntries={["/categories/new"]}
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <App />
-      </MemoryRouter>
-    )
+      </MemoryRouter>,
+    );
 
     // 新規作成フォームが表示されることを確認
-    expect(screen.getByText(/新規作成/)).toBeInTheDocument()
-  })
+    expect(screen.getByText(/新規作成/)).toBeInTheDocument();
+  });
 
   // 概要: /categories/:id/editパスでカテゴリ編集フォームが表示されることをテスト
   // 目的: /categories/:id/editルートが正しくCategoryFormコンポーネントを表示することを保証
-  it('renders CategoryForm at /categories/:id/edit path', () => {
+  it("renders CategoryForm at /categories/:id/edit path", () => {
     render(
       <MemoryRouter
-        initialEntries={['/categories/work/edit']}
+        initialEntries={["/categories/work/edit"]}
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <App />
-      </MemoryRouter>
-    )
+      </MemoryRouter>,
+    );
 
     // 編集フォームが表示されることを確認
-    expect(screen.getByText(/編集/)).toBeInTheDocument()
-  })
+    expect(screen.getByText(/編集/)).toBeInTheDocument();
+  });
 
   // 概要: 存在しないパスで404ページが表示されることをテスト
   // 目的: 存在しないルートが正しくNotFoundPageコンポーネントを表示することを保証
-  it('renders NotFoundPage for non-existent paths', () => {
+  it("renders NotFoundPage for non-existent paths", () => {
     render(
       <MemoryRouter
-        initialEntries={['/non-existent']}
+        initialEntries={["/non-existent"]}
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <App />
-      </MemoryRouter>
-    )
+      </MemoryRouter>,
+    );
 
     // 404ページが表示されることを確認
-    expect(screen.getByText(/404/)).toBeInTheDocument()
-  })
+    expect(screen.getByText(/404/)).toBeInTheDocument();
+  });
 
   // 概要: ナビゲーションバーが全ページで表示されることをテスト
   // 目的: Navigationコンポーネントが各ルートで正しく表示されることを保証
-  it('renders Navigation on all pages', () => {
+  it("renders Navigation on all pages", () => {
     render(
       <MemoryRouter
-        initialEntries={['/']}
+        initialEntries={["/"]}
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <App />
-      </MemoryRouter>
-    )
+      </MemoryRouter>,
+    );
 
     // ナビゲーションタブが表示されることを確認
     expect(
-      screen.getByRole('tablist', { name: 'navigation tabs' })
-    ).toBeInTheDocument()
-    expect(screen.getByRole('tab', { name: 'Todo page' })).toBeInTheDocument()
+      screen.getByRole("tablist", { name: "navigation tabs" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Todo page" })).toBeInTheDocument();
     expect(
-      screen.getByRole('tab', { name: 'Categories management page' })
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("tab", { name: "Categories management page" }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: アプリ全体でThemeProviderが適用されることをテスト
   // 目的: 全てのページでダークモードテーマが適用されることを保証
-  it('applies theme to all pages', () => {
+  it("applies theme to all pages", () => {
     mockUseDarkMode.mockReturnValue({
       isDarkMode: true,
       toggleDarkMode: vi.fn(),
       setDarkMode: vi.fn(),
-    })
+    });
 
     render(
       <MemoryRouter
-        initialEntries={['/categories']}
+        initialEntries={["/categories"]}
         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <App />
-      </MemoryRouter>
-    )
+      </MemoryRouter>,
+    );
 
     // カテゴリ管理のheading要素を確認（ナビゲーションではない方）
-    const categoryHeading = screen.getByRole('heading', {
+    const categoryHeading = screen.getByRole("heading", {
       name: /カテゴリ管理/i,
-    })
-    expect(categoryHeading).toBeInTheDocument()
-  })
-})
+    });
+    expect(categoryHeading).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/CategoriesPage.test.tsx
+++ b/frontend/__tests__/components/CategoriesPage.test.tsx
@@ -1,48 +1,48 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { MemoryRouter } from 'react-router-dom'
-import { CategoriesPage } from '../../src/components/CategoriesPage'
-import type { Category } from '../../src/types/category'
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { CategoriesPage } from "../../src/components/CategoriesPage";
+import type { Category } from "../../src/types/category";
 
 // useNavigateをモック
-const mockNavigate = vi.fn()
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom')
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
   return {
     ...actual,
     useNavigate: () => mockNavigate,
-  }
-})
+  };
+});
 
 // useCategoryManagementをモック
-const mockDeleteCategory = vi.fn()
+const mockDeleteCategory = vi.fn();
 const mockCategories: Category[] = [
   {
-    id: 'work',
-    name: '仕事',
-    color: '#1976d2',
-    description: '仕事関連のタスク',
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
+    id: "work",
+    name: "仕事",
+    color: "#1976d2",
+    description: "仕事関連のタスク",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
   },
   {
-    id: 'private',
-    name: 'プライベート',
-    color: '#ff5722',
-    description: '個人的なタスク',
-    createdAt: new Date('2024-01-02'),
-    updatedAt: new Date('2024-01-02'),
+    id: "private",
+    name: "プライベート",
+    color: "#ff5722",
+    description: "個人的なタスク",
+    createdAt: new Date("2024-01-02"),
+    updatedAt: new Date("2024-01-02"),
   },
-]
+];
 
-vi.mock('../../src/hooks/useCategoryManagement', () => ({
+vi.mock("../../src/hooks/useCategoryManagement", () => ({
   useCategoryManagement: () => ({
     categories: mockCategories,
     createCategory: vi.fn(),
     updateCategory: vi.fn(),
     deleteCategory: mockDeleteCategory,
   }),
-}))
+}));
 
 const renderWithRouter = () => {
   return render(
@@ -50,81 +50,83 @@ const renderWithRouter = () => {
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <CategoriesPage />
-    </MemoryRouter>
-  )
-}
+    </MemoryRouter>,
+  );
+};
 
-describe('CategoriesPage', () => {
+describe("CategoriesPage", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.clearAllMocks();
     // window.confirmをモック
-    Object.defineProperty(window, 'confirm', {
+    Object.defineProperty(window, "confirm", {
       writable: true,
       value: vi.fn().mockReturnValue(true),
-    })
-  })
+    });
+  });
 
   // 概要: カテゴリ一覧ページの基本表示をテスト
   // 目的: ページタイトルと新規作成ボタンが表示されることを保証（Issue #5要件）
-  it('displays page title and new button', () => {
-    renderWithRouter()
+  it("displays page title and new button", () => {
+    renderWithRouter();
 
-    expect(screen.getByText('カテゴリ管理')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '新規作成' })).toBeInTheDocument()
-  })
+    expect(screen.getByText("カテゴリ管理")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "新規作成" }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: カテゴリ一覧の表示をテスト
   // 目的: 全てのカテゴリが名前と共に表示されることを保証（Issue #5要件）
-  it('displays all categories with names', () => {
-    renderWithRouter()
+  it("displays all categories with names", () => {
+    renderWithRouter();
 
-    expect(screen.getByText('仕事')).toBeInTheDocument()
-    expect(screen.getByText('プライベート')).toBeInTheDocument()
-  })
+    expect(screen.getByText("仕事")).toBeInTheDocument();
+    expect(screen.getByText("プライベート")).toBeInTheDocument();
+  });
 
   // 概要: 新規作成ボタンの遷移機能をテスト
   // 目的: 新規作成ボタンクリック時に/categories/newに遷移することを保証（Issue #5要件）
-  it('navigates to new category page when new button clicked', () => {
-    renderWithRouter()
+  it("navigates to new category page when new button clicked", () => {
+    renderWithRouter();
 
-    const newButton = screen.getByRole('button', { name: '新規作成' })
-    fireEvent.click(newButton)
+    const newButton = screen.getByRole("button", { name: "新規作成" });
+    fireEvent.click(newButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/categories/new')
-  })
+    expect(mockNavigate).toHaveBeenCalledWith("/categories/new");
+  });
 
   // 概要: 編集ボタンの表示と遷移機能をテスト
   // 目的: 各カテゴリに編集ボタンが表示され、クリック時に適切な編集ページに遷移することを保証（Issue #5要件）
-  it('displays edit buttons and navigates to edit page', () => {
-    renderWithRouter()
+  it("displays edit buttons and navigates to edit page", () => {
+    renderWithRouter();
 
-    const editButtons = screen.getAllByRole('button', { name: '編集' })
-    expect(editButtons).toHaveLength(2) // 2つのカテゴリ分
+    const editButtons = screen.getAllByRole("button", { name: "編集" });
+    expect(editButtons).toHaveLength(2); // 2つのカテゴリ分
 
-    fireEvent.click(editButtons[0])
-    expect(mockNavigate).toHaveBeenCalledWith('/categories/work/edit')
-  })
+    fireEvent.click(editButtons[0]);
+    expect(mockNavigate).toHaveBeenCalledWith("/categories/work/edit");
+  });
 
   // 概要: 削除ボタンの表示と確認ダイアログをテスト
   // 目的: 各カテゴリに削除ボタンが表示され、クリック時に確認ダイアログが表示されることを保証（Issue #5要件）
-  it('displays delete buttons and shows confirmation dialog', () => {
-    renderWithRouter()
+  it("displays delete buttons and shows confirmation dialog", () => {
+    renderWithRouter();
 
-    const deleteButtons = screen.getAllByRole('button', { name: '削除' })
-    expect(deleteButtons).toHaveLength(2) // 2つのカテゴリ分
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    expect(deleteButtons).toHaveLength(2); // 2つのカテゴリ分
 
-    fireEvent.click(deleteButtons[0])
-    expect(window.confirm).toHaveBeenCalledWith('このカテゴリを削除しますか？')
-  })
+    fireEvent.click(deleteButtons[0]);
+    expect(window.confirm).toHaveBeenCalledWith("このカテゴリを削除しますか？");
+  });
 
   // 概要: 削除機能の実行をテスト
   // 目的: 確認ダイアログでOKが選択された場合、削除処理が実行されることを保証（Issue #5要件）
-  it('calls delete function when confirmed', () => {
-    renderWithRouter()
+  it("calls delete function when confirmed", () => {
+    renderWithRouter();
 
-    const deleteButtons = screen.getAllByRole('button', { name: '削除' })
-    fireEvent.click(deleteButtons[0])
+    const deleteButtons = screen.getAllByRole("button", { name: "削除" });
+    fireEvent.click(deleteButtons[0]);
 
-    expect(mockDeleteCategory).toHaveBeenCalledWith('work')
-  })
-})
+    expect(mockDeleteCategory).toHaveBeenCalledWith("work");
+  });
+});

--- a/frontend/__tests__/components/CategoryForm.test.tsx
+++ b/frontend/__tests__/components/CategoryForm.test.tsx
@@ -1,35 +1,35 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { MemoryRouter } from 'react-router-dom'
-import { CategoryForm } from '../../src/components/CategoryForm'
-import type { Category } from '../../src/types/category'
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { CategoryForm } from "../../src/components/CategoryForm";
+import type { Category } from "../../src/types/category";
 
 // useParamsとuseNavigateをモック
-const mockNavigate = vi.fn()
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom')
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
   return {
     ...actual,
     useParams: vi.fn(),
     useNavigate: () => mockNavigate,
-  }
-})
+  };
+});
 
 // useCategoryManagementをモック
-const mockCreateCategory = vi.fn()
-const mockUpdateCategory = vi.fn()
+const mockCreateCategory = vi.fn();
+const mockUpdateCategory = vi.fn();
 const mockCategories: Category[] = [
   {
-    id: 'work',
-    name: '仕事',
-    color: '#1976d2',
-    description: '仕事関連のタスク',
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
+    id: "work",
+    name: "仕事",
+    color: "#1976d2",
+    description: "仕事関連のタスク",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
   },
-]
+];
 
-vi.mock('../../src/hooks/useCategoryManagement', () => ({
+vi.mock("../../src/hooks/useCategoryManagement", () => ({
   useCategoryManagement: () => ({
     categories: mockCategories,
     createCategory: mockCreateCategory,
@@ -37,213 +37,213 @@ vi.mock('../../src/hooks/useCategoryManagement', () => ({
     deleteCategory: vi.fn(),
     isCategoryInUse: vi.fn(),
   }),
-}))
+}));
 
-const renderWithRouter = (initialPath: string = '/categories/new') => {
+const renderWithRouter = (initialPath: string = "/categories/new") => {
   return render(
     <MemoryRouter
       initialEntries={[initialPath]}
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <CategoryForm />
-    </MemoryRouter>
-  )
-}
+    </MemoryRouter>,
+  );
+};
 
-describe('CategoryForm', () => {
+describe("CategoryForm", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   // 概要: 新規作成モードでフォームが正しく表示されることをテスト
   // 目的: /categories/newパスで新規作成フォームが適切に初期化されることを保証
-  it('renders create form correctly', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({})
+  it("renders create form correctly", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({});
 
-    renderWithRouter()
+    renderWithRouter();
 
-    expect(screen.getByText('カテゴリ新規作成')).toBeInTheDocument()
+    expect(screen.getByText("カテゴリ新規作成")).toBeInTheDocument();
     expect(
-      screen.getByRole('textbox', { name: /カテゴリ名/ })
-    ).toBeInTheDocument()
-    expect(screen.getByDisplayValue('#1976d2')).toBeInTheDocument() // 色フィールド
-    expect(screen.getByRole('textbox', { name: /説明/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '作成' })).toBeInTheDocument()
+      screen.getByRole("textbox", { name: /カテゴリ名/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("#1976d2")).toBeInTheDocument(); // 色フィールド
+    expect(screen.getByRole("textbox", { name: /説明/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "作成" })).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'キャンセル' })
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("button", { name: "キャンセル" }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: 編集モードでフォームが正しく表示されることをテスト
   // 目的: /categories/:id/editパスで編集フォームが適切に初期化されることを保証
-  it('renders edit form correctly', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({ id: 'work' })
+  it("renders edit form correctly", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({ id: "work" });
 
-    renderWithRouter('/categories/work/edit')
+    renderWithRouter("/categories/work/edit");
 
-    expect(screen.getByText('カテゴリ編集')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('仕事')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('#1976d2')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('仕事関連のタスク')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '更新' })).toBeInTheDocument()
-  })
+    expect(screen.getByText("カテゴリ編集")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("仕事")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("#1976d2")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("仕事関連のタスク")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "更新" })).toBeInTheDocument();
+  });
 
   // 概要: 新規作成時のフォーム入力機能をテスト
   // 目的: ユーザーがフォームフィールドに正しく入力できることを保証
-  it('allows user input in create mode', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({})
+  it("allows user input in create mode", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({});
 
-    renderWithRouter()
+    renderWithRouter();
 
-    const nameInput = screen.getByRole('textbox', { name: /カテゴリ名/ })
-    const colorInput = screen.getByDisplayValue('#1976d2') // 色フィールド
-    const descriptionInput = screen.getByRole('textbox', { name: /説明/ })
+    const nameInput = screen.getByRole("textbox", { name: /カテゴリ名/ });
+    const colorInput = screen.getByDisplayValue("#1976d2"); // 色フィールド
+    const descriptionInput = screen.getByRole("textbox", { name: /説明/ });
 
-    fireEvent.change(nameInput, { target: { value: '学習' } })
-    fireEvent.change(colorInput, { target: { value: '#4caf50' } })
+    fireEvent.change(nameInput, { target: { value: "学習" } });
+    fireEvent.change(colorInput, { target: { value: "#4caf50" } });
     fireEvent.change(descriptionInput, {
-      target: { value: '学習関連のタスク' },
-    })
+      target: { value: "学習関連のタスク" },
+    });
 
-    expect(nameInput).toHaveValue('学習')
-    expect(colorInput).toHaveValue('#4caf50')
-    expect(descriptionInput).toHaveValue('学習関連のタスク')
-  })
+    expect(nameInput).toHaveValue("学習");
+    expect(colorInput).toHaveValue("#4caf50");
+    expect(descriptionInput).toHaveValue("学習関連のタスク");
+  });
 
   // 概要: 新規作成フォームの送信機能をテスト
   // 目的: 作成ボタンクリック時に正しくカテゴリが作成されることを保証
-  it('submits create form correctly', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({})
+  it("submits create form correctly", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({});
 
-    renderWithRouter()
+    renderWithRouter();
 
-    const nameInput = screen.getByRole('textbox', { name: /カテゴリ名/ })
-    const colorInput = screen.getByDisplayValue('#1976d2') // 色フィールド
-    const descriptionInput = screen.getByRole('textbox', { name: /説明/ })
-    const submitButton = screen.getByRole('button', { name: '作成' })
+    const nameInput = screen.getByRole("textbox", { name: /カテゴリ名/ });
+    const colorInput = screen.getByDisplayValue("#1976d2"); // 色フィールド
+    const descriptionInput = screen.getByRole("textbox", { name: /説明/ });
+    const submitButton = screen.getByRole("button", { name: "作成" });
 
-    fireEvent.change(nameInput, { target: { value: '学習' } })
-    fireEvent.change(colorInput, { target: { value: '#4caf50' } })
+    fireEvent.change(nameInput, { target: { value: "学習" } });
+    fireEvent.change(colorInput, { target: { value: "#4caf50" } });
     fireEvent.change(descriptionInput, {
-      target: { value: '学習関連のタスク' },
-    })
+      target: { value: "学習関連のタスク" },
+    });
 
-    fireEvent.click(submitButton)
+    fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockCreateCategory).toHaveBeenCalledWith({
-        name: '学習',
-        color: '#4caf50',
-        description: '学習関連のタスク',
-      })
-    })
+        name: "学習",
+        color: "#4caf50",
+        description: "学習関連のタスク",
+      });
+    });
 
-    expect(mockNavigate).toHaveBeenCalledWith('/categories')
-  })
+    expect(mockNavigate).toHaveBeenCalledWith("/categories");
+  });
 
   // 概要: 編集フォームの送信機能をテスト
   // 目的: 更新ボタンクリック時に正しくカテゴリが更新されることを保証
-  it('submits edit form correctly', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({ id: 'work' })
+  it("submits edit form correctly", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({ id: "work" });
 
-    renderWithRouter('/categories/work/edit')
+    renderWithRouter("/categories/work/edit");
 
-    const nameInput = screen.getByDisplayValue('仕事')
-    const submitButton = screen.getByRole('button', { name: '更新' })
+    const nameInput = screen.getByDisplayValue("仕事");
+    const submitButton = screen.getByRole("button", { name: "更新" });
 
-    fireEvent.change(nameInput, { target: { value: '重要な仕事' } })
-    fireEvent.click(submitButton)
+    fireEvent.change(nameInput, { target: { value: "重要な仕事" } });
+    fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(mockUpdateCategory).toHaveBeenCalledWith('work', {
-        name: '重要な仕事',
-        color: '#1976d2',
-        description: '仕事関連のタスク',
-      })
-    })
+      expect(mockUpdateCategory).toHaveBeenCalledWith("work", {
+        name: "重要な仕事",
+        color: "#1976d2",
+        description: "仕事関連のタスク",
+      });
+    });
 
-    expect(mockNavigate).toHaveBeenCalledWith('/categories')
-  })
+    expect(mockNavigate).toHaveBeenCalledWith("/categories");
+  });
 
   // 概要: 必須フィールドのバリデーション機能をテスト
   // 目的: カテゴリ名が空の場合にエラーメッセージが表示されることを保証
-  it('shows validation error for empty name', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({})
+  it("shows validation error for empty name", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({});
 
-    renderWithRouter()
+    renderWithRouter();
 
     // フォーム要素を見つけて直接submitする
-    const form = document.querySelector('form')
+    const form = document.querySelector("form");
     if (form) {
-      fireEvent.submit(form)
+      fireEvent.submit(form);
     }
 
     await waitFor(
       () => {
         // エラー状態の確認
-        const nameInput = screen.getByRole('textbox', { name: /カテゴリ名/ })
-        expect(nameInput).toHaveAttribute('aria-invalid', 'true')
+        const nameInput = screen.getByRole("textbox", { name: /カテゴリ名/ });
+        expect(nameInput).toHaveAttribute("aria-invalid", "true");
       },
-      { timeout: 3000 }
-    )
+      { timeout: 3000 },
+    );
 
     // helperTextの確認
-    expect(screen.getByText('カテゴリ名は必須です')).toBeInTheDocument()
+    expect(screen.getByText("カテゴリ名は必須です")).toBeInTheDocument();
 
-    expect(mockCreateCategory).not.toHaveBeenCalled()
-  })
+    expect(mockCreateCategory).not.toHaveBeenCalled();
+  });
 
   // 概要: 重複チェック機能をテスト
   // 目的: 既存のカテゴリ名と重複する場合にエラーが表示されることを保証
-  it('shows validation error for duplicate name', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({})
+  it("shows validation error for duplicate name", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({});
 
-    renderWithRouter()
+    renderWithRouter();
 
-    const nameInput = screen.getByRole('textbox', { name: /カテゴリ名/ })
-    const submitButton = screen.getByRole('button', { name: '作成' })
+    const nameInput = screen.getByRole("textbox", { name: /カテゴリ名/ });
+    const submitButton = screen.getByRole("button", { name: "作成" });
 
-    fireEvent.change(nameInput, { target: { value: '仕事' } }) // 既存の名前
-    fireEvent.click(submitButton)
+    fireEvent.change(nameInput, { target: { value: "仕事" } }); // 既存の名前
+    fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(
-        screen.getByText('このカテゴリ名は既に存在します')
-      ).toBeInTheDocument()
-    })
+        screen.getByText("このカテゴリ名は既に存在します"),
+      ).toBeInTheDocument();
+    });
 
-    expect(mockCreateCategory).not.toHaveBeenCalled()
-  })
+    expect(mockCreateCategory).not.toHaveBeenCalled();
+  });
 
   // 概要: キャンセル機能をテスト
   // 目的: キャンセルボタンクリック時にカテゴリ一覧に戻ることを保証
-  it('navigates to categories on cancel', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({})
+  it("navigates to categories on cancel", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({});
 
-    renderWithRouter()
+    renderWithRouter();
 
-    const cancelButton = screen.getByRole('button', { name: 'キャンセル' })
-    fireEvent.click(cancelButton)
+    const cancelButton = screen.getByRole("button", { name: "キャンセル" });
+    fireEvent.click(cancelButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/categories')
-  })
+    expect(mockNavigate).toHaveBeenCalledWith("/categories");
+  });
 
   // 概要: 存在しないカテゴリの編集でエラー表示をテスト
   // 目的: 存在しないIDで編集画面にアクセスした場合の適切な処理を保証
-  it('shows error for non-existent category in edit mode', async () => {
-    const { useParams } = vi.mocked(await import('react-router-dom'))
-    useParams.mockReturnValue({ id: 'non-existent' })
+  it("shows error for non-existent category in edit mode", async () => {
+    const { useParams } = vi.mocked(await import("react-router-dom"));
+    useParams.mockReturnValue({ id: "non-existent" });
 
-    renderWithRouter('/categories/non-existent/edit')
+    renderWithRouter("/categories/non-existent/edit");
 
-    expect(screen.getByText('カテゴリが見つかりません')).toBeInTheDocument()
-  })
-})
+    expect(screen.getByText("カテゴリが見つかりません")).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/FilterBar.test.tsx
+++ b/frontend/__tests__/components/FilterBar.test.tsx
@@ -1,31 +1,31 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import { FilterBar } from '../../src/components/FilterBar'
-import type { FilterState } from '../../src/types/filter'
-import type { Category } from '../../src/types/category'
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { FilterBar } from "../../src/components/FilterBar";
+import type { FilterState } from "../../src/types/filter";
+import type { Category } from "../../src/types/category";
 
 const mockCategories: Category[] = [
-  { id: 'work', name: '仕事', color: '#1976d2' },
-  { id: 'personal', name: 'プライベート', color: '#ff5722' },
-  { id: 'other', name: 'その他', color: '#9e9e9e' },
-]
+  { id: "work", name: "仕事", color: "#1976d2" },
+  { id: "personal", name: "プライベート", color: "#ff5722" },
+  { id: "other", name: "その他", color: "#9e9e9e" },
+];
 
-const mockAvailableTags = ['urgent', 'shopping', 'learning', 'meeting']
+const mockAvailableTags = ["urgent", "shopping", "learning", "meeting"];
 
 const defaultFilters: FilterState = {
-  completionStatus: 'all',
+  completionStatus: "all",
   categoryIds: [],
   tags: [],
-  tagCondition: 'any',
-  searchText: '',
-}
+  tagCondition: "any",
+  searchText: "",
+};
 
-describe('FilterBar', () => {
+describe("FilterBar", () => {
   // 概要: フィルターバーの基本UI要素が表示されることを確認
   // 目的: 全てのフィルター操作UI要素が適切にレンダリングされることを保証
-  it('renders all filter UI elements', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("renders all filter UI elements", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -35,32 +35,34 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
     // 完了状態フィルター
-    expect(screen.getByRole('group', { name: /完了状態/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("group", { name: /完了状態/i }),
+    ).toBeInTheDocument();
 
     // カテゴリフィルター
-    expect(screen.getByLabelText(/カテゴリ/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/カテゴリ/i)).toBeInTheDocument();
 
     // タグフィルター
-    expect(screen.getByRole('combobox', { name: /タグ/i })).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { name: /タグ/i })).toBeInTheDocument();
 
     // 検索フィルター
-    expect(screen.getByLabelText(/検索/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/検索/i)).toBeInTheDocument();
 
     // リセットボタン
     expect(
-      screen.getByRole('button', { name: /リセット/i })
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("button", { name: /リセット/i }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: 完了状態フィルターの変更時にコールバックが呼ばれることを確認
   // 目的: 完了状態切り替えUIが正しく動作することを保証
-  it('calls onFiltersChange when completion status changes', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("calls onFiltersChange when completion status changes", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -70,22 +72,22 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
-    const completedButton = screen.getByRole('button', { name: /完了済み/i })
-    fireEvent.click(completedButton)
+    const completedButton = screen.getByRole("button", { name: /完了済み/i });
+    fireEvent.click(completedButton);
 
     expect(mockOnFiltersChange).toHaveBeenCalledWith({
-      completionStatus: 'completed',
-    })
-  })
+      completionStatus: "completed",
+    });
+  });
 
   // 概要: カテゴリフィルターの変更時にコールバックが呼ばれることを確認
   // 目的: カテゴリ選択UIが正しく動作することを保証
-  it('calls onFiltersChange when category changes', async () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("calls onFiltersChange when category changes", async () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -95,27 +97,27 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
-    const categorySelect = screen.getByLabelText(/カテゴリ/i)
-    fireEvent.mouseDown(categorySelect)
+    const categorySelect = screen.getByLabelText(/カテゴリ/i);
+    fireEvent.mouseDown(categorySelect);
 
     await waitFor(() => {
-      const workOption = screen.getByText('仕事')
-      fireEvent.click(workOption)
-    })
+      const workOption = screen.getByText("仕事");
+      fireEvent.click(workOption);
+    });
 
     expect(mockOnFiltersChange).toHaveBeenCalledWith({
-      categoryIds: ['work'],
-    })
-  })
+      categoryIds: ["work"],
+    });
+  });
 
   // 概要: タグフィルターの変更時にコールバックが呼ばれることを確認
   // 目的: タグ選択UIが正しく動作することを保証
-  it('calls onFiltersChange when tags change', async () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("calls onFiltersChange when tags change", async () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -125,30 +127,30 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
-    const tagInput = screen.getByRole('combobox', { name: /タグ/i })
+    const tagInput = screen.getByRole("combobox", { name: /タグ/i });
 
     // Autocompleteにフォーカスして入力を開始
-    fireEvent.focus(tagInput)
-    fireEvent.change(tagInput, { target: { value: 'ur' } })
+    fireEvent.focus(tagInput);
+    fireEvent.change(tagInput, { target: { value: "ur" } });
 
     await waitFor(() => {
-      const urgentOption = screen.getByText('urgent')
-      fireEvent.click(urgentOption)
-    })
+      const urgentOption = screen.getByText("urgent");
+      fireEvent.click(urgentOption);
+    });
 
     expect(mockOnFiltersChange).toHaveBeenCalledWith({
-      tags: ['urgent'],
-    })
-  })
+      tags: ["urgent"],
+    });
+  });
 
   // 概要: 検索フィルターの変更時にコールバックが呼ばれることを確認
   // 目的: 検索入力UIが正しく動作することを保証
-  it('calls onFiltersChange when search text changes', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("calls onFiltersChange when search text changes", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -158,22 +160,22 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
-    const searchInput = screen.getByLabelText(/検索/i)
-    fireEvent.change(searchInput, { target: { value: 'test search' } })
+    const searchInput = screen.getByLabelText(/検索/i);
+    fireEvent.change(searchInput, { target: { value: "test search" } });
 
     expect(mockOnFiltersChange).toHaveBeenCalledWith({
-      searchText: 'test search',
-    })
-  })
+      searchText: "test search",
+    });
+  });
 
   // 概要: タグ条件切り替えの動作確認
   // 目的: AND/OR条件の切り替えUIが正しく動作することを保証
-  it('allows switching tag condition between any and all', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("allows switching tag condition between any and all", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -183,22 +185,22 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
-    const tagConditionToggle = screen.getByLabelText(/タグ条件/i)
-    fireEvent.click(tagConditionToggle)
+    const tagConditionToggle = screen.getByLabelText(/タグ条件/i);
+    fireEvent.click(tagConditionToggle);
 
     expect(mockOnFiltersChange).toHaveBeenCalledWith({
-      tagCondition: 'all',
-    })
-  })
+      tagCondition: "all",
+    });
+  });
 
   // 概要: リセットボタンの動作確認
   // 目的: フィルターリセット機能が正しく動作することを保証
-  it('calls onReset when reset button is clicked', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("calls onReset when reset button is clicked", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -208,20 +210,20 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={3}
-      />
-    )
+      />,
+    );
 
-    const resetButton = screen.getByRole('button', { name: /リセット/i })
-    fireEvent.click(resetButton)
+    const resetButton = screen.getByRole("button", { name: /リセット/i });
+    fireEvent.click(resetButton);
 
-    expect(mockOnReset).toHaveBeenCalled()
-  })
+    expect(mockOnReset).toHaveBeenCalled();
+  });
 
   // 概要: アクティブフィルター数の表示確認
   // 目的: 現在適用されているフィルター数が視覚的に表示されることを保証
-  it('displays active filter count', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("displays active filter count", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -231,17 +233,17 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={3}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText('3')).toBeInTheDocument()
-  })
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
 
   // 概要: アクティブフィルターがない場合のバッジ非表示確認
   // 目的: フィルターが設定されていない時に不要な表示がされないことを保証
-  it('does not display badge when no active filters', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("does not display badge when no active filters", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -251,26 +253,26 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
-    const badge = screen.queryByText('0')
-    expect(badge).not.toBeInTheDocument()
-  })
+    const badge = screen.queryByText("0");
+    expect(badge).not.toBeInTheDocument();
+  });
 
   // 概要: 現在のフィルター値の表示確認
   // 目的: 設定済みフィルターが適切にUIに反映されることを保証
-  it('displays current filter values', () => {
+  it("displays current filter values", () => {
     const activeFilters: FilterState = {
-      completionStatus: 'completed',
-      categoryIds: ['work'],
-      tags: ['urgent'],
-      tagCondition: 'all',
-      searchText: 'test',
-    }
+      completionStatus: "completed",
+      categoryIds: ["work"],
+      tags: ["urgent"],
+      tagCondition: "all",
+      searchText: "test",
+    };
 
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -280,23 +282,23 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={4}
-      />
-    )
+      />,
+    );
 
     // 完了済みが選択されている
-    const completedButton = screen.getByRole('button', { name: /完了済み/i })
-    expect(completedButton).toHaveAttribute('aria-pressed', 'true')
+    const completedButton = screen.getByRole("button", { name: /完了済み/i });
+    expect(completedButton).toHaveAttribute("aria-pressed", "true");
 
     // 検索テキストが入力されている
-    const searchInput = screen.getByDisplayValue('test')
-    expect(searchInput).toBeInTheDocument()
-  })
+    const searchInput = screen.getByDisplayValue("test");
+    expect(searchInput).toBeInTheDocument();
+  });
 
   // 概要: 空のカテゴリリストの処理確認
   // 目的: データが不足している場合でもUIが正常に動作することを保証
-  it('handles empty categories list', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("handles empty categories list", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -306,18 +308,18 @@ describe('FilterBar', () => {
         categories={[]}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
-    const categorySelect = screen.getByLabelText(/カテゴリ/i)
-    expect(categorySelect).toBeInTheDocument()
-  })
+    const categorySelect = screen.getByLabelText(/カテゴリ/i);
+    expect(categorySelect).toBeInTheDocument();
+  });
 
   // 概要: 空のタグリストの処理確認
   // 目的: データが不足している場合でもUIが正常に動作することを保証
-  it('handles empty tags list', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("handles empty tags list", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -327,18 +329,18 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={[]}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
-    const tagInput = screen.getByRole('combobox', { name: /タグ/i })
-    expect(tagInput).toBeInTheDocument()
-  })
+    const tagInput = screen.getByRole("combobox", { name: /タグ/i });
+    expect(tagInput).toBeInTheDocument();
+  });
 
   // 概要: アクセシビリティ対応の確認
   // 目的: 適切なaria-labelやroleが設定されていることを保証
-  it('has proper accessibility attributes', () => {
-    const mockOnFiltersChange = vi.fn()
-    const mockOnReset = vi.fn()
+  it("has proper accessibility attributes", () => {
+    const mockOnFiltersChange = vi.fn();
+    const mockOnReset = vi.fn();
 
     render(
       <FilterBar
@@ -348,15 +350,17 @@ describe('FilterBar', () => {
         categories={mockCategories}
         availableTags={mockAvailableTags}
         activeFilterCount={0}
-      />
-    )
+      />,
+    );
 
     // 各フィルターにラベルが適切に設定されている
-    expect(screen.getByLabelText(/カテゴリ/i)).toBeInTheDocument()
-    expect(screen.getByRole('combobox', { name: /タグ/i })).toBeInTheDocument()
-    expect(screen.getByLabelText(/検索/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/カテゴリ/i)).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /タグ/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/検索/i)).toBeInTheDocument();
 
     // 完了状態フィルターにgroup roleが設定されている
-    expect(screen.getByRole('group', { name: /完了状態/i })).toBeInTheDocument()
-  })
-})
+    expect(
+      screen.getByRole("group", { name: /完了状態/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/Navigation.test.tsx
+++ b/frontend/__tests__/components/Navigation.test.tsx
@@ -1,14 +1,14 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
-import { MemoryRouter } from 'react-router-dom'
-import { ThemeProvider, createTheme } from '@mui/material'
-import { Navigation } from '../../src/components/Navigation'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider, createTheme } from "@mui/material";
+import { Navigation } from "../../src/components/Navigation";
 
 const renderWithRouter = (initialPath: string) => {
   const mockProps = {
     isDarkMode: false,
     toggleDarkMode: () => {},
-  }
+  };
 
   return render(
     <MemoryRouter
@@ -16,24 +16,24 @@ const renderWithRouter = (initialPath: string) => {
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <Navigation {...mockProps} />
-    </MemoryRouter>
-  )
-}
+    </MemoryRouter>,
+  );
+};
 
 const renderWithTheme = (
   initialPath: string,
-  mode: 'light' | 'dark' = 'light'
+  mode: "light" | "dark" = "light",
 ) => {
   const theme = createTheme({
     palette: {
       mode,
     },
-  })
+  });
 
   const mockProps = {
-    isDarkMode: mode === 'dark',
+    isDarkMode: mode === "dark",
     toggleDarkMode: () => {},
-  }
+  };
 
   return render(
     <MemoryRouter
@@ -43,131 +43,131 @@ const renderWithTheme = (
       <ThemeProvider theme={theme}>
         <Navigation {...mockProps} />
       </ThemeProvider>
-    </MemoryRouter>
-  )
-}
+    </MemoryRouter>,
+  );
+};
 
-describe('Navigation', () => {
+describe("Navigation", () => {
   // 概要: ルートパス（/）でTodoタブが選択されることをテスト
   // 目的: ホームページでTodoタブがアクティブ状態になることを保証
-  it('selects Todo tab when on root path', () => {
-    renderWithRouter('/')
+  it("selects Todo tab when on root path", () => {
+    renderWithRouter("/");
 
-    const todoTab = screen.getByRole('tab', { name: 'Todo page' })
-    const categoryTab = screen.getByRole('tab', {
-      name: 'Categories management page',
-    })
+    const todoTab = screen.getByRole("tab", { name: "Todo page" });
+    const categoryTab = screen.getByRole("tab", {
+      name: "Categories management page",
+    });
 
-    expect(todoTab).toHaveAttribute('aria-selected', 'true')
-    expect(categoryTab).toHaveAttribute('aria-selected', 'false')
-  })
+    expect(todoTab).toHaveAttribute("aria-selected", "true");
+    expect(categoryTab).toHaveAttribute("aria-selected", "false");
+  });
 
   // 概要: カテゴリ管理パス（/categories）でカテゴリタブが選択されることをテスト
   // 目的: カテゴリ管理ページでカテゴリタブがアクティブ状態になることを保証
-  it('selects Category tab when on categories path', () => {
-    renderWithRouter('/categories')
+  it("selects Category tab when on categories path", () => {
+    renderWithRouter("/categories");
 
-    const todoTab = screen.getByRole('tab', { name: 'Todo page' })
-    const categoryTab = screen.getByRole('tab', {
-      name: 'Categories management page',
-    })
+    const todoTab = screen.getByRole("tab", { name: "Todo page" });
+    const categoryTab = screen.getByRole("tab", {
+      name: "Categories management page",
+    });
 
-    expect(todoTab).toHaveAttribute('aria-selected', 'false')
-    expect(categoryTab).toHaveAttribute('aria-selected', 'true')
-  })
+    expect(todoTab).toHaveAttribute("aria-selected", "false");
+    expect(categoryTab).toHaveAttribute("aria-selected", "true");
+  });
 
   // 概要: カテゴリ新規作成パス（/categories/new）でカテゴリタブが選択されることをテスト
   // 目的: カテゴリ関連のサブページでもカテゴリタブがアクティブ状態になることを保証
-  it('selects Category tab when on categories/new path', () => {
-    renderWithRouter('/categories/new')
+  it("selects Category tab when on categories/new path", () => {
+    renderWithRouter("/categories/new");
 
-    const todoTab = screen.getByRole('tab', { name: 'Todo page' })
-    const categoryTab = screen.getByRole('tab', {
-      name: 'Categories management page',
-    })
+    const todoTab = screen.getByRole("tab", { name: "Todo page" });
+    const categoryTab = screen.getByRole("tab", {
+      name: "Categories management page",
+    });
 
-    expect(todoTab).toHaveAttribute('aria-selected', 'false')
-    expect(categoryTab).toHaveAttribute('aria-selected', 'true')
-  })
+    expect(todoTab).toHaveAttribute("aria-selected", "false");
+    expect(categoryTab).toHaveAttribute("aria-selected", "true");
+  });
 
   // 概要: カテゴリ編集パス（/categories/:id/edit）でカテゴリタブが選択されることをテスト
   // 目的: カテゴリ編集ページでもカテゴリタブがアクティブ状態になることを保証
-  it('selects Category tab when on categories edit path', () => {
-    renderWithRouter('/categories/work/edit')
+  it("selects Category tab when on categories edit path", () => {
+    renderWithRouter("/categories/work/edit");
 
-    const todoTab = screen.getByRole('tab', { name: 'Todo page' })
-    const categoryTab = screen.getByRole('tab', {
-      name: 'Categories management page',
-    })
+    const todoTab = screen.getByRole("tab", { name: "Todo page" });
+    const categoryTab = screen.getByRole("tab", {
+      name: "Categories management page",
+    });
 
-    expect(todoTab).toHaveAttribute('aria-selected', 'false')
-    expect(categoryTab).toHaveAttribute('aria-selected', 'true')
-  })
+    expect(todoTab).toHaveAttribute("aria-selected", "false");
+    expect(categoryTab).toHaveAttribute("aria-selected", "true");
+  });
 
   // 概要: 存在しないパスでどのタブも選択されないことをテスト
   // 目的: 404ページなどの未定義ルートでタブ選択状態が適切に処理されることを保証
-  it('selects no tab when on unknown path', () => {
-    renderWithRouter('/unknown-path')
+  it("selects no tab when on unknown path", () => {
+    renderWithRouter("/unknown-path");
 
-    const todoTab = screen.getByRole('tab', { name: 'Todo page' })
-    const categoryTab = screen.getByRole('tab', {
-      name: 'Categories management page',
-    })
+    const todoTab = screen.getByRole("tab", { name: "Todo page" });
+    const categoryTab = screen.getByRole("tab", {
+      name: "Categories management page",
+    });
 
-    expect(todoTab).toHaveAttribute('aria-selected', 'false')
-    expect(categoryTab).toHaveAttribute('aria-selected', 'false')
-  })
+    expect(todoTab).toHaveAttribute("aria-selected", "false");
+    expect(categoryTab).toHaveAttribute("aria-selected", "false");
+  });
 
   // 概要: Todoタブが正しいリンク先を持つことをテスト
   // 目的: Todoタブクリック時に正しいURLに遷移できることを保証
-  it('has correct href for Todo tab', () => {
-    renderWithRouter('/')
+  it("has correct href for Todo tab", () => {
+    renderWithRouter("/");
 
-    const todoTab = screen.getByRole('tab', { name: 'Todo page' })
-    expect(todoTab).toHaveAttribute('href', '/')
-  })
+    const todoTab = screen.getByRole("tab", { name: "Todo page" });
+    expect(todoTab).toHaveAttribute("href", "/");
+  });
 
   // 概要: カテゴリタブが正しいリンク先を持つことをテスト
   // 目的: カテゴリタブクリック時に正しいURLに遷移できることを保証
-  it('has correct href for Category tab', () => {
-    renderWithRouter('/')
+  it("has correct href for Category tab", () => {
+    renderWithRouter("/");
 
-    const categoryTab = screen.getByRole('tab', {
-      name: 'Categories management page',
-    })
-    expect(categoryTab).toHaveAttribute('href', '/categories')
-  })
+    const categoryTab = screen.getByRole("tab", {
+      name: "Categories management page",
+    });
+    expect(categoryTab).toHaveAttribute("href", "/categories");
+  });
 
   // 概要: ダークモード切り替えボタンが表示されることをテスト
   // 目的: ナビゲーションにダークモード切り替え機能が含まれることを保証
-  it('displays dark mode toggle button', () => {
-    renderWithTheme('/', 'light')
+  it("displays dark mode toggle button", () => {
+    renderWithTheme("/", "light");
 
-    const toggleButton = screen.getByRole('button', {
-      name: 'Switch to dark mode',
-    })
-    expect(toggleButton).toBeInTheDocument()
-  })
+    const toggleButton = screen.getByRole("button", {
+      name: "Switch to dark mode",
+    });
+    expect(toggleButton).toBeInTheDocument();
+  });
 
   // 概要: ライトモード時に正しいアイコンが表示されることをテスト
   // 目的: ダークモード切り替えボタンが現在の状態を正しく反映することを保証
-  it('shows dark mode icon when in light mode', () => {
-    renderWithTheme('/', 'light')
+  it("shows dark mode icon when in light mode", () => {
+    renderWithTheme("/", "light");
 
-    const toggleButton = screen.getByRole('button', {
-      name: 'Switch to dark mode',
-    })
-    expect(toggleButton).toBeInTheDocument()
-  })
+    const toggleButton = screen.getByRole("button", {
+      name: "Switch to dark mode",
+    });
+    expect(toggleButton).toBeInTheDocument();
+  });
 
   // 概要: ダークモード時に正しいアイコンが表示されることをテスト
   // 目的: ダークモード切り替えボタンが現在の状態を正しく反映することを保証
-  it('shows light mode icon when in dark mode', () => {
-    renderWithTheme('/', 'dark')
+  it("shows light mode icon when in dark mode", () => {
+    renderWithTheme("/", "dark");
 
-    const toggleButton = screen.getByRole('button', {
-      name: 'Switch to light mode',
-    })
-    expect(toggleButton).toBeInTheDocument()
-  })
-})
+    const toggleButton = screen.getByRole("button", {
+      name: "Switch to light mode",
+    });
+    expect(toggleButton).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/NotFoundPage.test.tsx
+++ b/frontend/__tests__/components/NotFoundPage.test.tsx
@@ -1,17 +1,17 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { MemoryRouter } from 'react-router-dom'
-import { NotFoundPage } from '../../src/components/NotFoundPage'
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { NotFoundPage } from "../../src/components/NotFoundPage";
 
 // useNavigateをモック
-const mockNavigate = vi.fn()
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom')
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
   return {
     ...actual,
     useNavigate: () => mockNavigate,
-  }
-})
+  };
+});
 
 const renderWithRouter = () => {
   return render(
@@ -19,75 +19,77 @@ const renderWithRouter = () => {
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <NotFoundPage />
-    </MemoryRouter>
-  )
-}
+    </MemoryRouter>,
+  );
+};
 
-describe('NotFoundPage', () => {
+describe("NotFoundPage", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   // 概要: 404ページの基本表示をテスト
   // 目的: 404エラーメッセージとページタイトルが表示されることを保証（Issue #5要件）
-  it('displays 404 error message and page title', () => {
-    renderWithRouter()
+  it("displays 404 error message and page title", () => {
+    renderWithRouter();
 
-    expect(screen.getByText('404')).toBeInTheDocument()
-    expect(screen.getByText('ページが見つかりません')).toBeInTheDocument()
-  })
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(screen.getByText("ページが見つかりません")).toBeInTheDocument();
+  });
 
   // 概要: エラーの詳細説明をテスト
   // 目的: ユーザーに分かりやすいエラー説明が表示されることを保証（Issue #5要件）
-  it('displays user-friendly error description', () => {
-    renderWithRouter()
+  it("displays user-friendly error description", () => {
+    renderWithRouter();
 
     expect(
-      screen.getByText('お探しのページは存在しないか、移動した可能性があります')
-    ).toBeInTheDocument()
-  })
+      screen.getByText(
+        "お探しのページは存在しないか、移動した可能性があります",
+      ),
+    ).toBeInTheDocument();
+  });
 
   // 概要: ホームページへの戻るボタンをテスト
   // 目的: ユーザーがメインページに戻れるナビゲーションが提供されることを保証（Issue #5要件）
-  it('displays home navigation button', () => {
-    renderWithRouter()
+  it("displays home navigation button", () => {
+    renderWithRouter();
 
     expect(
-      screen.getByRole('button', { name: 'ホームに戻る' })
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("button", { name: "ホームに戻る" }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: ホームへの遷移機能をテスト
   // 目的: ホームボタンクリック時にルートページに遷移することを保証（Issue #5要件）
-  it('navigates to home when home button clicked', () => {
-    renderWithRouter()
+  it("navigates to home when home button clicked", () => {
+    renderWithRouter();
 
-    const homeButton = screen.getByRole('button', { name: 'ホームに戻る' })
-    fireEvent.click(homeButton)
+    const homeButton = screen.getByRole("button", { name: "ホームに戻る" });
+    fireEvent.click(homeButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/')
-  })
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
 
   // 概要: カテゴリページへの戻るボタンをテスト
   // 目的: カテゴリ管理ページに戻れるナビゲーションが提供されることを保証（Issue #5要件）
-  it('displays category navigation button', () => {
-    renderWithRouter()
+  it("displays category navigation button", () => {
+    renderWithRouter();
 
     expect(
-      screen.getByRole('button', { name: 'カテゴリ管理に戻る' })
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("button", { name: "カテゴリ管理に戻る" }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: カテゴリページへの遷移機能をテスト
   // 目的: カテゴリボタンクリック時にカテゴリページに遷移することを保証（Issue #5要件）
-  it('navigates to categories when category button clicked', () => {
-    renderWithRouter()
+  it("navigates to categories when category button clicked", () => {
+    renderWithRouter();
 
-    const categoryButton = screen.getByRole('button', {
-      name: 'カテゴリ管理に戻る',
-    })
-    fireEvent.click(categoryButton)
+    const categoryButton = screen.getByRole("button", {
+      name: "カテゴリ管理に戻る",
+    });
+    fireEvent.click(categoryButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/categories')
-  })
-})
+    expect(mockNavigate).toHaveBeenCalledWith("/categories");
+  });
+});

--- a/frontend/__tests__/components/SortableTodoItem.test.tsx
+++ b/frontend/__tests__/components/SortableTodoItem.test.tsx
@@ -1,87 +1,87 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import '@testing-library/jest-dom'
-import { DndContext } from '@dnd-kit/core'
-import type { Todo } from '../../src/types/todo'
-import type { Category } from '../../src/types/category'
-import { SortableTodoItem } from '../../src/components/SortableTodoItem'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { DndContext } from "@dnd-kit/core";
+import type { Todo } from "../../src/types/todo";
+import type { Category } from "../../src/types/category";
+import { SortableTodoItem } from "../../src/components/SortableTodoItem";
 
-describe('SortableTodoItem', () => {
+describe("SortableTodoItem", () => {
   const mockTodo: Todo = {
-    id: '1',
-    text: 'Test todo',
+    id: "1",
+    text: "Test todo",
     completed: false,
-    createdAt: new Date('2023-01-01'),
-    categoryId: 'category1',
-    tags: ['tag1'],
+    createdAt: new Date("2023-01-01"),
+    categoryId: "category1",
+    tags: ["tag1"],
     order: 0,
-  }
+  };
 
   const mockCategories: Category[] = [
-    { id: 'category1', name: 'Work', color: '#1976d2' },
-  ]
+    { id: "category1", name: "Work", color: "#1976d2" },
+  ];
 
-  const mockOnToggle = vi.fn()
-  const mockOnDelete = vi.fn()
-  const mockOnEdit = vi.fn()
+  const mockOnToggle = vi.fn();
+  const mockOnDelete = vi.fn();
+  const mockOnEdit = vi.fn();
 
   const renderWithDndContext = (component: React.ReactElement) => {
-    return render(<DndContext>{component}</DndContext>)
-  }
+    return render(<DndContext>{component}</DndContext>);
+  };
 
   // 概要: SortableTodoItemが正しくレンダリングされることをテスト
   // 目的: コンポーネントが基本的な要素（TodoItem、ドラッグハンドル）を含むことを保証
-  it('renders todo item with drag handle', () => {
+  it("renders todo item with drag handle", () => {
     renderWithDndContext(
       <SortableTodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText('Test todo')).toBeInTheDocument()
-    expect(screen.getByLabelText('Drag to reorder')).toBeInTheDocument()
-  })
+    expect(screen.getByText("Test todo")).toBeInTheDocument();
+    expect(screen.getByLabelText("Drag to reorder")).toBeInTheDocument();
+  });
 
   // 概要: ドラッグハンドルがデフォルトで非表示になっていることをテスト
   // 目的: UIの初期状態でドラッグハンドルが目立たないことを保証
-  it('has drag handle hidden by default', () => {
+  it("has drag handle hidden by default", () => {
     renderWithDndContext(
       <SortableTodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const dragHandle = screen.getByLabelText('Drag to reorder')
-    expect(dragHandle).toHaveStyle({ opacity: 0 })
-  })
+    const dragHandle = screen.getByLabelText("Drag to reorder");
+    expect(dragHandle).toHaveStyle({ opacity: 0 });
+  });
 
   // 概要: TodoItemコンポーネントが適切なpropsで呼び出されることをテスト
   // 目的: SortableTodoItemがTodoItemを正しくラップしていることを保証
-  it('passes correct props to TodoItem', () => {
+  it("passes correct props to TodoItem", () => {
     renderWithDndContext(
       <SortableTodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
     // TodoItemの内容が表示されることを確認
-    expect(screen.getByText('Test todo')).toBeInTheDocument()
+    expect(screen.getByText("Test todo")).toBeInTheDocument();
     // カテゴリが表示されることを確認
-    expect(screen.getByText('Work')).toBeInTheDocument()
-  })
+    expect(screen.getByText("Work")).toBeInTheDocument();
+  });
 
   // 概要: onEditプロパティがTodoItemに正しく渡されることをテスト
   // 目的: 編集機能がSortableTodoItem経由でも正常に動作することを保証
-  it('passes onEdit prop to TodoItem when provided', () => {
+  it("passes onEdit prop to TodoItem when provided", () => {
     renderWithDndContext(
       <SortableTodoItem
         todo={mockTodo}
@@ -89,28 +89,28 @@ describe('SortableTodoItem', () => {
         onDelete={mockOnDelete}
         onEdit={mockOnEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
     // 編集ボタンが表示されることを確認（TodoItemが正しくonEditを受け取っている証拠）
-    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument()
-  })
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
 
   // 概要: onEditが提供されない場合の動作をテスト
   // 目的: 編集機能が無効な場合でも正常に動作することを保証
-  it('works correctly when onEdit is not provided', () => {
+  it("works correctly when onEdit is not provided", () => {
     renderWithDndContext(
       <SortableTodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
     // 編集ボタンが表示されないことを確認
     expect(
-      screen.queryByRole('button', { name: /edit/i })
-    ).not.toBeInTheDocument()
-  })
-})
+      screen.queryByRole("button", { name: /edit/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/TodoApp.test.tsx
+++ b/frontend/__tests__/components/TodoApp.test.tsx
@@ -1,314 +1,316 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, beforeEach } from 'vitest'
-import { TodoApp } from '../../src/components/TodoApp'
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { TodoApp } from "../../src/components/TodoApp";
 
-describe('TodoApp', () => {
+describe("TodoApp", () => {
   beforeEach(() => {
     // 各テスト前にlocalStorageをクリア
-    localStorage.clear()
-  })
+    localStorage.clear();
+  });
   // 概要: アプリケーションのタイトルが正しく表示されることを確認
   // 目的: UIの基本構造が正しくレンダリングされることを保証
-  it('renders todo app title', () => {
-    render(<TodoApp />)
+  it("renders todo app title", () => {
+    render(<TodoApp />);
     expect(
-      screen.getByRole('heading', { name: /todo app/i })
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("heading", { name: /todo app/i }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: 新しいTodoを入力するためのフィールドが表示されることを確認
   // 目的: ユーザーがTodoを入力できるUIが提供されていることを保証
-  it('renders input field for new todo', () => {
-    render(<TodoApp />)
+  it("renders input field for new todo", () => {
+    render(<TodoApp />);
     expect(
-      screen.getByPlaceholderText('新しいタスクを入力')
-    ).toBeInTheDocument()
-  })
+      screen.getByPlaceholderText("新しいタスクを入力"),
+    ).toBeInTheDocument();
+  });
 
   // 概要: Todoを追加するためのボタンが表示されることを確認
   // 目的: ユーザーがTodoを追加するアクションを実行できることを保証
-  it('renders add button', () => {
-    render(<TodoApp />)
-    expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument()
-  })
+  it("renders add button", () => {
+    render(<TodoApp />);
+    expect(screen.getByRole("button", { name: "追加" })).toBeInTheDocument();
+  });
 
   // 概要: フォームが送信されたときに新しいTodoが追加されることを確認
   // 目的: Todo追加機能の基本動作が正しく実装されていることを保証
-  it('adds new todo when form is submitted', () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("adds new todo when form is submitted", () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
-    fireEvent.change(input, { target: { value: 'Learn React' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Learn React" } });
+    fireEvent.click(addButton);
 
-    expect(screen.getByText('Learn React')).toBeInTheDocument()
-  })
+    expect(screen.getByText("Learn React")).toBeInTheDocument();
+  });
 
   // 概要: Todoを追加した後、入力フィールドがクリアされることを確認
   // 目的: UXの向上とユーザーが連続してTodoを追加できることを保証
-  it('clears input after adding todo', () => {
-    render(<TodoApp />)
+  it("clears input after adding todo", () => {
+    render(<TodoApp />);
     const input = screen.getByPlaceholderText(
-      '新しいタスクを入力'
-    ) as HTMLInputElement
-    const addButton = screen.getByRole('button', { name: '追加' })
+      "新しいタスクを入力",
+    ) as HTMLInputElement;
+    const addButton = screen.getByRole("button", { name: "追加" });
 
-    fireEvent.change(input, { target: { value: 'Learn React' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Learn React" } });
+    fireEvent.click(addButton);
 
-    expect(input.value).toBe('')
-  })
+    expect(input.value).toBe("");
+  });
 
   // 概要: Todoの完了状態を切り替えられることを確認
   // 目的: Todo完了機能が正しく動作することを保証
-  it('toggles todo completion status', () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("toggles todo completion status", () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
-    fireEvent.change(input, { target: { value: 'Learn React' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Learn React" } });
+    fireEvent.click(addButton);
 
     // Todo項目のcheckboxを特定（data-testidなどで区別）
-    const todoCheckboxes = screen.getAllByRole('checkbox')
+    const todoCheckboxes = screen.getAllByRole("checkbox");
     const todoCheckbox = todoCheckboxes.find(
-      checkbox =>
-        checkbox.getAttribute('data-indeterminate') === 'false' &&
-        checkbox.tabIndex === -1
-    )
+      (checkbox) =>
+        checkbox.getAttribute("data-indeterminate") === "false" &&
+        checkbox.tabIndex === -1,
+    );
 
-    expect(todoCheckbox).not.toBeChecked()
+    expect(todoCheckbox).not.toBeChecked();
 
-    fireEvent.click(todoCheckbox!)
-    expect(todoCheckbox).toBeChecked()
-  })
+    fireEvent.click(todoCheckbox!);
+    expect(todoCheckbox).toBeChecked();
+  });
 
   // 概要: 削除ボタンをクリックしたときにTodoが削除されることを確認
   // 目的: Todo削除機能が正しく動作することを保証
-  it('deletes todo when delete button is clicked', () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("deletes todo when delete button is clicked", () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
-    fireEvent.change(input, { target: { value: 'Learn React' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Learn React" } });
+    fireEvent.click(addButton);
 
-    expect(screen.getByText('Learn React')).toBeInTheDocument()
+    expect(screen.getByText("Learn React")).toBeInTheDocument();
 
-    const deleteButton = screen.getByLabelText(/delete/i)
-    fireEvent.click(deleteButton)
+    const deleteButton = screen.getByLabelText(/delete/i);
+    fireEvent.click(deleteButton);
 
-    expect(screen.queryByText('Learn React')).not.toBeInTheDocument()
-  })
+    expect(screen.queryByText("Learn React")).not.toBeInTheDocument();
+  });
 
   // 概要: 空のTodoが追加されないことを確認
   // 目的: バリデーション機能が正しく動作し、無効なデータの登録を防ぐことを保証
-  it('does not add empty todo', () => {
-    render(<TodoApp />)
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("does not add empty todo", () => {
+    render(<TodoApp />);
+    const addButton = screen.getByRole("button", { name: "追加" });
 
-    fireEvent.click(addButton)
+    fireEvent.click(addButton);
 
     // FilterBarのSwitchではなく、Todo項目のcheckboxがないことを確認
-    const todoCheckboxes = screen.getAllByRole('checkbox')
+    const todoCheckboxes = screen.getAllByRole("checkbox");
     const todoCheckbox = todoCheckboxes.find(
-      checkbox =>
-        checkbox.getAttribute('data-indeterminate') === 'false' &&
-        checkbox.tabIndex === -1
-    )
-    expect(todoCheckbox).toBeUndefined()
-  })
+      (checkbox) =>
+        checkbox.getAttribute("data-indeterminate") === "false" &&
+        checkbox.tabIndex === -1,
+    );
+    expect(todoCheckbox).toBeUndefined();
+  });
 
   // 概要: フィルターバーが表示されることを確認
   // 目的: フィルター機能のUIが正しく統合されていることを保証
-  it('renders filter bar', () => {
-    render(<TodoApp />)
+  it("renders filter bar", () => {
+    render(<TodoApp />);
 
     // 完了状態フィルター
-    expect(screen.getByRole('group', { name: /完了状態/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("group", { name: /完了状態/i }),
+    ).toBeInTheDocument();
 
     // カテゴリフィルター（FilterBar内の）
-    const categoryFilterElements = screen.getAllByLabelText('カテゴリ')
-    expect(categoryFilterElements.length).toBeGreaterThan(0)
+    const categoryFilterElements = screen.getAllByLabelText("カテゴリ");
+    expect(categoryFilterElements.length).toBeGreaterThan(0);
 
     // タグフィルター
-    expect(screen.getByRole('combobox', { name: /タグ/i })).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { name: /タグ/i })).toBeInTheDocument();
 
     // 検索フィルター
-    expect(screen.getByLabelText(/検索/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/検索/i)).toBeInTheDocument();
 
     // リセットボタン
-    expect(screen.getByText('リセット')).toBeInTheDocument()
-  })
+    expect(screen.getByText("リセット")).toBeInTheDocument();
+  });
 
   // 概要: 完了状態フィルターが機能することを確認
   // 目的: 完了状態によるTodoの絞り込みが正しく動作することを保証
-  it('filters todos by completion status', async () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("filters todos by completion status", async () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
     // 2つのTodoを追加
-    fireEvent.change(input, { target: { value: 'Task 1' } })
-    fireEvent.click(addButton)
-    fireEvent.change(input, { target: { value: 'Task 2' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Task 1" } });
+    fireEvent.click(addButton);
+    fireEvent.change(input, { target: { value: "Task 2" } });
+    fireEvent.click(addButton);
 
     // 1つ目を完了にする
-    const todoCheckboxes = screen.getAllByRole('checkbox')
+    const todoCheckboxes = screen.getAllByRole("checkbox");
     const todoCheckbox = todoCheckboxes.find(
-      checkbox =>
-        checkbox.getAttribute('data-indeterminate') === 'false' &&
-        checkbox.tabIndex === -1
-    )
-    fireEvent.click(todoCheckbox!)
+      (checkbox) =>
+        checkbox.getAttribute("data-indeterminate") === "false" &&
+        checkbox.tabIndex === -1,
+    );
+    fireEvent.click(todoCheckbox!);
 
     // 完了済みフィルターを選択
-    const completedButton = screen.getByLabelText('完了済み')
-    fireEvent.click(completedButton)
+    const completedButton = screen.getByLabelText("完了済み");
+    fireEvent.click(completedButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Task 1')).toBeInTheDocument()
-      expect(screen.queryByText('Task 2')).not.toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText("Task 1")).toBeInTheDocument();
+      expect(screen.queryByText("Task 2")).not.toBeInTheDocument();
+    });
+  });
 
   // 概要: 検索フィルターが機能することを確認
   // 目的: テキスト検索によるTodoの絞り込みが正しく動作することを保証
-  it('filters todos by search text', async () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("filters todos by search text", async () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
     // 2つのTodoを追加
-    fireEvent.change(input, { target: { value: 'Learn React' } })
-    fireEvent.click(addButton)
-    fireEvent.change(input, { target: { value: 'Learn Vue' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Learn React" } });
+    fireEvent.click(addButton);
+    fireEvent.change(input, { target: { value: "Learn Vue" } });
+    fireEvent.click(addButton);
 
     // 検索フィルターを入力
-    const searchInput = screen.getByLabelText(/検索/i)
-    fireEvent.change(searchInput, { target: { value: 'React' } })
+    const searchInput = screen.getByLabelText(/検索/i);
+    fireEvent.change(searchInput, { target: { value: "React" } });
 
     await waitFor(() => {
-      expect(screen.getByText('Learn React')).toBeInTheDocument()
-      expect(screen.queryByText('Learn Vue')).not.toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText("Learn React")).toBeInTheDocument();
+      expect(screen.queryByText("Learn Vue")).not.toBeInTheDocument();
+    });
+  });
 
   // 概要: フィルターリセット機能が動作することを確認
   // 目的: 全てのフィルターが初期状態に戻ることを保証
-  it('resets filters when reset button is clicked', async () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("resets filters when reset button is clicked", async () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
     // Todoを追加
-    fireEvent.change(input, { target: { value: 'Test Task' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Test Task" } });
+    fireEvent.click(addButton);
 
     // 検索フィルターを適用
-    const searchInput = screen.getByLabelText(/検索/i)
-    fireEvent.change(searchInput, { target: { value: 'nonexistent' } })
+    const searchInput = screen.getByLabelText(/検索/i);
+    fireEvent.change(searchInput, { target: { value: "nonexistent" } });
 
     await waitFor(() => {
-      expect(screen.queryByText('Test Task')).not.toBeInTheDocument()
-    })
+      expect(screen.queryByText("Test Task")).not.toBeInTheDocument();
+    });
 
     // リセットボタンをクリック
-    const resetButton = screen.getByText('リセット')
-    fireEvent.click(resetButton)
+    const resetButton = screen.getByText("リセット");
+    fireEvent.click(resetButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Test Task')).toBeInTheDocument()
-      expect(searchInput).toHaveValue('')
-    })
-  })
+      expect(screen.getByText("Test Task")).toBeInTheDocument();
+      expect(searchInput).toHaveValue("");
+    });
+  });
 
   // 概要: Todoの編集機能が正常に動作することを確認
   // 目的: ユーザーが既存のTodoを編集できることを保証
-  it('allows editing todo text', async () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("allows editing todo text", async () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
     // Todoを追加
-    fireEvent.change(input, { target: { value: 'Original Task' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Original Task" } });
+    fireEvent.click(addButton);
 
     // 編集ボタンをクリック
-    const editButton = screen.getByRole('button', { name: /edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /edit/i });
+    fireEvent.click(editButton);
 
     // テキストを変更
-    const editInput = screen.getByDisplayValue('Original Task')
-    fireEvent.change(editInput, { target: { value: 'Updated Task' } })
+    const editInput = screen.getByDisplayValue("Original Task");
+    fireEvent.change(editInput, { target: { value: "Updated Task" } });
 
     // 保存ボタンをクリック
-    const saveButton = screen.getByRole('button', { name: /保存|save/i })
-    fireEvent.click(saveButton)
+    const saveButton = screen.getByRole("button", { name: /保存|save/i });
+    fireEvent.click(saveButton);
 
     // 更新されたテキストが表示されることを確認
     await waitFor(() => {
-      expect(screen.getByText('Updated Task')).toBeInTheDocument()
-      expect(screen.queryByText('Original Task')).not.toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText("Updated Task")).toBeInTheDocument();
+      expect(screen.queryByText("Original Task")).not.toBeInTheDocument();
+    });
+  });
 
   // 概要: Todo編集のキャンセル機能が正常に動作することを確認
   // 目的: ユーザーが編集を取り消せることを保証
-  it('allows canceling todo edit', async () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("allows canceling todo edit", async () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
     // Todoを追加
-    fireEvent.change(input, { target: { value: 'Original Task' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Original Task" } });
+    fireEvent.click(addButton);
 
     // 編集ボタンをクリック
-    const editButton = screen.getByRole('button', { name: /edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /edit/i });
+    fireEvent.click(editButton);
 
     // テキストを変更
-    const editInput = screen.getByDisplayValue('Original Task')
-    fireEvent.change(editInput, { target: { value: 'Updated Task' } })
+    const editInput = screen.getByDisplayValue("Original Task");
+    fireEvent.change(editInput, { target: { value: "Updated Task" } });
 
     // キャンセルボタンをクリック
-    const cancelButton = screen.getByRole('button', {
+    const cancelButton = screen.getByRole("button", {
       name: /キャンセル|cancel/i,
-    })
-    fireEvent.click(cancelButton)
+    });
+    fireEvent.click(cancelButton);
 
     // 元のテキストが表示されることを確認
     await waitFor(() => {
-      expect(screen.getByText('Original Task')).toBeInTheDocument()
-      expect(screen.queryByText('Updated Task')).not.toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText("Original Task")).toBeInTheDocument();
+      expect(screen.queryByText("Updated Task")).not.toBeInTheDocument();
+    });
+  });
 
   // 概要: ダブルクリックでTodo編集モードに入ることを確認
   // 目的: ユーザビリティを向上させる直感的な編集操作が機能することを保証
-  it('allows editing todo by double click', async () => {
-    render(<TodoApp />)
-    const input = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: '追加' })
+  it("allows editing todo by double click", async () => {
+    render(<TodoApp />);
+    const input = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: "追加" });
 
     // Todoを追加
-    fireEvent.change(input, { target: { value: 'Double Click Task' } })
-    fireEvent.click(addButton)
+    fireEvent.change(input, { target: { value: "Double Click Task" } });
+    fireEvent.click(addButton);
 
     // Todoテキストをダブルクリック
-    const todoText = screen.getByText('Double Click Task')
-    fireEvent.doubleClick(todoText)
+    const todoText = screen.getByText("Double Click Task");
+    fireEvent.doubleClick(todoText);
 
     // 編集フィールドが表示されることを確認
     await waitFor(() => {
-      expect(screen.getByDisplayValue('Double Click Task')).toBeInTheDocument()
+      expect(screen.getByDisplayValue("Double Click Task")).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /保存|save/i })
-      ).toBeInTheDocument()
-    })
-  })
-})
+        screen.getByRole("button", { name: /保存|save/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/__tests__/components/TodoEditForm.test.tsx
+++ b/frontend/__tests__/components/TodoEditForm.test.tsx
@@ -1,26 +1,26 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import { TodoEditForm } from '../../src/components/TodoEditForm'
-import type { EditTodoData } from '../../src/types/todo'
-import type { Category } from '../../src/types/category'
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TodoEditForm } from "../../src/components/TodoEditForm";
+import type { EditTodoData } from "../../src/types/todo";
+import type { Category } from "../../src/types/category";
 
 const mockCategories: Category[] = [
-  { id: 'cat1', name: '仕事', color: '#2196f3' },
-  { id: 'cat2', name: '個人', color: '#4caf50' },
-]
+  { id: "cat1", name: "仕事", color: "#2196f3" },
+  { id: "cat2", name: "個人", color: "#4caf50" },
+];
 
 const mockEditData: EditTodoData = {
-  text: 'Edit this todo',
-  categoryId: 'cat1',
-  tags: ['tag1', 'tag2'],
-}
+  text: "Edit this todo",
+  categoryId: "cat1",
+  tags: ["tag1", "tag2"],
+};
 
-describe('TodoEditForm', () => {
+describe("TodoEditForm", () => {
   // 概要: TodoEditFormコンポーネントの初期表示をテスト
   // 目的: 初期データが正しくフォームフィールドに表示されることを保証
-  it('renders with initial edit data', () => {
-    const onSave = vi.fn()
-    const onCancel = vi.fn()
+  it("renders with initial edit data", () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <TodoEditForm
@@ -29,20 +29,20 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={vi.fn()}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByDisplayValue('Edit this todo')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('tag1, tag2')).toBeInTheDocument()
-    expect(screen.getByText('仕事')).toBeInTheDocument()
-  })
+    expect(screen.getByDisplayValue("Edit this todo")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("tag1, tag2")).toBeInTheDocument();
+    expect(screen.getByText("仕事")).toBeInTheDocument();
+  });
 
   // 概要: テキスト入力の変更をテスト
   // 目的: テキストフィールドの変更がonUpdateDataコールバックを呼び出すことを保証
-  it('calls onUpdateData when text input changes', () => {
-    const onUpdateData = vi.fn()
-    const onSave = vi.fn()
-    const onCancel = vi.fn()
+  it("calls onUpdateData when text input changes", () => {
+    const onUpdateData = vi.fn();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <TodoEditForm
@@ -51,21 +51,21 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={onUpdateData}
-      />
-    )
+      />,
+    );
 
-    const textInput = screen.getByDisplayValue('Edit this todo')
-    fireEvent.change(textInput, { target: { value: 'Updated todo text' } })
+    const textInput = screen.getByDisplayValue("Edit this todo");
+    fireEvent.change(textInput, { target: { value: "Updated todo text" } });
 
-    expect(onUpdateData).toHaveBeenCalledWith({ text: 'Updated todo text' })
-  })
+    expect(onUpdateData).toHaveBeenCalledWith({ text: "Updated todo text" });
+  });
 
   // 概要: カテゴリ選択の変更をテスト
   // 目的: カテゴリセレクトの変更がonUpdateDataコールバックを呼び出すことを保証
-  it('calls onUpdateData when category selection changes', () => {
-    const onUpdateData = vi.fn()
-    const onSave = vi.fn()
-    const onCancel = vi.fn()
+  it("calls onUpdateData when category selection changes", () => {
+    const onUpdateData = vi.fn();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <TodoEditForm
@@ -74,24 +74,24 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={onUpdateData}
-      />
-    )
+      />,
+    );
 
-    const categorySelect = screen.getByRole('combobox', { name: /カテゴリ/i })
-    fireEvent.mouseDown(categorySelect)
+    const categorySelect = screen.getByRole("combobox", { name: /カテゴリ/i });
+    fireEvent.mouseDown(categorySelect);
 
-    const personalOption = screen.getByRole('option', { name: '個人' })
-    fireEvent.click(personalOption)
+    const personalOption = screen.getByRole("option", { name: "個人" });
+    fireEvent.click(personalOption);
 
-    expect(onUpdateData).toHaveBeenCalledWith({ categoryId: 'cat2' })
-  })
+    expect(onUpdateData).toHaveBeenCalledWith({ categoryId: "cat2" });
+  });
 
   // 概要: タグ入力の変更をテスト
   // 目的: タグフィールドの変更がonUpdateDataコールバックを呼び出すことを保証
-  it('calls onUpdateData when tags input changes', () => {
-    const onUpdateData = vi.fn()
-    const onSave = vi.fn()
-    const onCancel = vi.fn()
+  it("calls onUpdateData when tags input changes", () => {
+    const onUpdateData = vi.fn();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <TodoEditForm
@@ -100,24 +100,24 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={onUpdateData}
-      />
-    )
+      />,
+    );
 
-    const tagsInput = screen.getByDisplayValue('tag1, tag2')
+    const tagsInput = screen.getByDisplayValue("tag1, tag2");
     fireEvent.change(tagsInput, {
-      target: { value: 'newtag1, newtag2, newtag3' },
-    })
+      target: { value: "newtag1, newtag2, newtag3" },
+    });
 
     expect(onUpdateData).toHaveBeenCalledWith({
-      tags: ['newtag1', 'newtag2', 'newtag3'],
-    })
-  })
+      tags: ["newtag1", "newtag2", "newtag3"],
+    });
+  });
 
   // 概要: 保存ボタンのクリックをテスト
   // 目的: 保存ボタンがクリックされた際にonSaveコールバックが呼ばれることを保証
-  it('calls onSave when save button is clicked', () => {
-    const onSave = vi.fn()
-    const onCancel = vi.fn()
+  it("calls onSave when save button is clicked", () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <TodoEditForm
@@ -126,20 +126,20 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={vi.fn()}
-      />
-    )
+      />,
+    );
 
-    const saveButton = screen.getByRole('button', { name: /保存|save/i })
-    fireEvent.click(saveButton)
+    const saveButton = screen.getByRole("button", { name: /保存|save/i });
+    fireEvent.click(saveButton);
 
-    expect(onSave).toHaveBeenCalled()
-  })
+    expect(onSave).toHaveBeenCalled();
+  });
 
   // 概要: キャンセルボタンのクリックをテスト
   // 目的: キャンセルボタンがクリックされた際にonCancelコールバックが呼ばれることを保証
-  it('calls onCancel when cancel button is clicked', () => {
-    const onCancel = vi.fn()
-    const onSave = vi.fn()
+  it("calls onCancel when cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    const onSave = vi.fn();
 
     render(
       <TodoEditForm
@@ -148,22 +148,22 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={vi.fn()}
-      />
-    )
+      />,
+    );
 
-    const cancelButton = screen.getByRole('button', {
+    const cancelButton = screen.getByRole("button", {
       name: /キャンセル|cancel/i,
-    })
-    fireEvent.click(cancelButton)
+    });
+    fireEvent.click(cancelButton);
 
-    expect(onCancel).toHaveBeenCalled()
-  })
+    expect(onCancel).toHaveBeenCalled();
+  });
 
   // 概要: Enterキーでの保存をテスト
   // 目的: テキストフィールドでEnterキーを押した際にonSaveが呼ばれることを保証
-  it('calls onSave when Enter key is pressed in text field', () => {
-    const onSave = vi.fn()
-    const onCancel = vi.fn()
+  it("calls onSave when Enter key is pressed in text field", () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <TodoEditForm
@@ -172,20 +172,24 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={vi.fn()}
-      />
-    )
+      />,
+    );
 
-    const textInput = screen.getByDisplayValue('Edit this todo')
-    fireEvent.keyPress(textInput, { key: 'Enter', code: 'Enter', charCode: 13 })
+    const textInput = screen.getByDisplayValue("Edit this todo");
+    fireEvent.keyPress(textInput, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+    });
 
-    expect(onSave).toHaveBeenCalled()
-  })
+    expect(onSave).toHaveBeenCalled();
+  });
 
   // 概要: Escapeキーでのキャンセルをテスト
   // 目的: Escapeキーを押した際にonCancelが呼ばれることを保証
-  it('calls onCancel when Escape key is pressed', () => {
-    const onCancel = vi.fn()
-    const onSave = vi.fn()
+  it("calls onCancel when Escape key is pressed", () => {
+    const onCancel = vi.fn();
+    const onSave = vi.fn();
 
     render(
       <TodoEditForm
@@ -194,21 +198,21 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={vi.fn()}
-      />
-    )
+      />,
+    );
 
-    const textInput = screen.getByDisplayValue('Edit this todo')
-    fireEvent.keyDown(textInput, { key: 'Escape', code: 'Escape' })
+    const textInput = screen.getByDisplayValue("Edit this todo");
+    fireEvent.keyDown(textInput, { key: "Escape", code: "Escape" });
 
-    expect(onCancel).toHaveBeenCalled()
-  })
+    expect(onCancel).toHaveBeenCalled();
+  });
 
   // 概要: カテゴリなしの選択をテスト
   // 目的: カテゴリを「なし」に変更した際にcategoryIdがundefinedになることを保証
   it('handles "none" category selection', () => {
-    const onUpdateData = vi.fn()
-    const onSave = vi.fn()
-    const onCancel = vi.fn()
+    const onUpdateData = vi.fn();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <TodoEditForm
@@ -217,23 +221,23 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={onUpdateData}
-      />
-    )
+      />,
+    );
 
-    const categorySelect = screen.getByRole('combobox', { name: /カテゴリ/i })
-    fireEvent.mouseDown(categorySelect)
+    const categorySelect = screen.getByRole("combobox", { name: /カテゴリ/i });
+    fireEvent.mouseDown(categorySelect);
 
-    const noneOption = screen.getByRole('option', { name: 'なし' })
-    fireEvent.click(noneOption)
+    const noneOption = screen.getByRole("option", { name: "なし" });
+    fireEvent.click(noneOption);
 
-    expect(onUpdateData).toHaveBeenCalledWith({ categoryId: undefined })
-  })
+    expect(onUpdateData).toHaveBeenCalledWith({ categoryId: undefined });
+  });
 
   // 概要: フォーカス管理をテスト
   // 目的: コンポーネントがマウントされた際にテキストフィールドにフォーカスが当たることを保証
-  it('focuses on text input when component mounts', () => {
-    const onSave = vi.fn()
-    const onCancel = vi.fn()
+  it("focuses on text input when component mounts", () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <TodoEditForm
@@ -242,10 +246,10 @@ describe('TodoEditForm', () => {
         onSave={onSave}
         onCancel={onCancel}
         onUpdateData={vi.fn()}
-      />
-    )
+      />,
+    );
 
-    const textInput = screen.getByDisplayValue('Edit this todo')
-    expect(textInput).toHaveFocus()
-  })
-})
+    const textInput = screen.getByDisplayValue("Edit this todo");
+    expect(textInput).toHaveFocus();
+  });
+});

--- a/frontend/__tests__/components/TodoForm.test.tsx
+++ b/frontend/__tests__/components/TodoForm.test.tsx
@@ -1,225 +1,229 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import { TodoForm } from '../../src/components/TodoForm'
-import type { Category } from '../../src/types/category'
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TodoForm } from "../../src/components/TodoForm";
+import type { Category } from "../../src/types/category";
 
 const mockCategories: Category[] = [
-  { id: 'work', name: '仕事', color: '#1976d2' },
-  { id: 'private', name: 'プライベート', color: '#ff5722' },
-  { id: 'other', name: 'その他', color: '#9e9e9e' },
-]
+  { id: "work", name: "仕事", color: "#1976d2" },
+  { id: "private", name: "プライベート", color: "#ff5722" },
+  { id: "other", name: "その他", color: "#9e9e9e" },
+];
 
-describe('TodoForm', () => {
+describe("TodoForm", () => {
   // 概要: Todoテキスト入力フィールドが表示されることを確認
   // 目的: 基本的な入力UIが正しく表示されることを保証
-  it('renders todo text input field', () => {
-    const mockOnSubmit = vi.fn()
+  it("renders todo text input field", () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const textInput = screen.getByPlaceholderText('新しいタスクを入力')
-    expect(textInput).toBeInTheDocument()
-  })
+    const textInput = screen.getByPlaceholderText("新しいタスクを入力");
+    expect(textInput).toBeInTheDocument();
+  });
 
   // 概要: カテゴリ選択フィールドが表示されることを確認
   // 目的: カテゴリ選択UIが適切に表示されることを保証
-  it('renders category selection field', () => {
-    const mockOnSubmit = vi.fn()
+  it("renders category selection field", () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const categorySelect = screen.getByLabelText('カテゴリ')
-    expect(categorySelect).toBeInTheDocument()
-  })
+    const categorySelect = screen.getByLabelText("カテゴリ");
+    expect(categorySelect).toBeInTheDocument();
+  });
 
   // 概要: タグ入力フィールドが表示されることを確認
   // 目的: タグ入力UIが適切に表示されることを保証
-  it('renders tag input field', () => {
-    const mockOnSubmit = vi.fn()
+  it("renders tag input field", () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const tagInput = screen.getByLabelText('タグ')
-    expect(tagInput).toBeInTheDocument()
-  })
+    const tagInput = screen.getByLabelText("タグ");
+    expect(tagInput).toBeInTheDocument();
+  });
 
   // 概要: 追加ボタンが表示されることを確認
   // 目的: フォーム送信ボタンが適切に表示されることを保証
-  it('renders add button', () => {
-    const mockOnSubmit = vi.fn()
+  it("renders add button", () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const addButton = screen.getByRole('button', { name: /追加/i })
-    expect(addButton).toBeInTheDocument()
-  })
+    const addButton = screen.getByRole("button", { name: /追加/i });
+    expect(addButton).toBeInTheDocument();
+  });
 
   // 概要: テキストを入力してフォームを送信できることを確認
   // 目的: 基本的なTodo作成機能が動作することを保証
-  it('submits form with text only', async () => {
-    const mockOnSubmit = vi.fn()
+  it("submits form with text only", async () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const textInput = screen.getByPlaceholderText('新しいタスクを入力')
-    const addButton = screen.getByRole('button', { name: /追加/i })
+    const textInput = screen.getByPlaceholderText("新しいタスクを入力");
+    const addButton = screen.getByRole("button", { name: /追加/i });
 
-    fireEvent.change(textInput, { target: { value: 'テストタスク' } })
-    fireEvent.click(addButton)
+    fireEvent.change(textInput, { target: { value: "テストタスク" } });
+    fireEvent.click(addButton);
 
     expect(mockOnSubmit).toHaveBeenCalledWith({
-      text: 'テストタスク',
+      text: "テストタスク",
       categoryId: undefined,
       tags: [],
-    })
-  })
+    });
+  });
 
   // 概要: カテゴリを選択してフォームを送信できることを確認
   // 目的: カテゴリ付きTodo作成機能が動作することを保証
-  it('submits form with category selected', async () => {
-    const mockOnSubmit = vi.fn()
+  it("submits form with category selected", async () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const textInput = screen.getByPlaceholderText('新しいタスクを入力')
-    const categorySelect = screen.getByLabelText('カテゴリ')
-    const addButton = screen.getByRole('button', { name: /追加/i })
+    const textInput = screen.getByPlaceholderText("新しいタスクを入力");
+    const categorySelect = screen.getByLabelText("カテゴリ");
+    const addButton = screen.getByRole("button", { name: /追加/i });
 
-    fireEvent.change(textInput, { target: { value: 'カテゴリ付きタスク' } })
-    fireEvent.mouseDown(categorySelect)
+    fireEvent.change(textInput, { target: { value: "カテゴリ付きタスク" } });
+    fireEvent.mouseDown(categorySelect);
 
     await waitFor(() => {
-      const workOption = screen.getByText('仕事')
-      fireEvent.click(workOption)
-    })
+      const workOption = screen.getByText("仕事");
+      fireEvent.click(workOption);
+    });
 
-    fireEvent.click(addButton)
+    fireEvent.click(addButton);
 
     expect(mockOnSubmit).toHaveBeenCalledWith({
-      text: 'カテゴリ付きタスク',
-      categoryId: 'work',
+      text: "カテゴリ付きタスク",
+      categoryId: "work",
       tags: [],
-    })
-  })
+    });
+  });
 
   // 概要: タグを入力してフォームを送信できることを確認
   // 目的: タグ付きTodo作成機能が動作することを保証
-  it('submits form with tags', async () => {
-    const mockOnSubmit = vi.fn()
+  it("submits form with tags", async () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const textInput = screen.getByPlaceholderText('新しいタスクを入力')
-    const tagInput = screen.getByLabelText('タグ')
-    const addButton = screen.getByRole('button', { name: /追加/i })
+    const textInput = screen.getByPlaceholderText("新しいタスクを入力");
+    const tagInput = screen.getByLabelText("タグ");
+    const addButton = screen.getByRole("button", { name: /追加/i });
 
-    fireEvent.change(textInput, { target: { value: 'タグ付きタスク' } })
-    fireEvent.change(tagInput, { target: { value: '重要, 急ぎ' } })
-    fireEvent.click(addButton)
+    fireEvent.change(textInput, { target: { value: "タグ付きタスク" } });
+    fireEvent.change(tagInput, { target: { value: "重要, 急ぎ" } });
+    fireEvent.click(addButton);
 
     expect(mockOnSubmit).toHaveBeenCalledWith({
-      text: 'タグ付きタスク',
+      text: "タグ付きタスク",
       categoryId: undefined,
-      tags: ['重要', '急ぎ'],
-    })
-  })
+      tags: ["重要", "急ぎ"],
+    });
+  });
 
   // 概要: カテゴリとタグの両方を設定してフォームを送信できることを確認
   // 目的: 完全なTodo作成機能が動作することを保証
-  it('submits form with both category and tags', async () => {
-    const mockOnSubmit = vi.fn()
+  it("submits form with both category and tags", async () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const textInput = screen.getByPlaceholderText('新しいタスクを入力')
-    const categorySelect = screen.getByLabelText('カテゴリ')
-    const tagInput = screen.getByLabelText('タグ')
-    const addButton = screen.getByRole('button', { name: /追加/i })
+    const textInput = screen.getByPlaceholderText("新しいタスクを入力");
+    const categorySelect = screen.getByLabelText("カテゴリ");
+    const tagInput = screen.getByLabelText("タグ");
+    const addButton = screen.getByRole("button", { name: /追加/i });
 
-    fireEvent.change(textInput, { target: { value: '完全なタスク' } })
+    fireEvent.change(textInput, { target: { value: "完全なタスク" } });
 
-    fireEvent.mouseDown(categorySelect)
+    fireEvent.mouseDown(categorySelect);
     await waitFor(() => {
-      const privateOption = screen.getByText('プライベート')
-      fireEvent.click(privateOption)
-    })
+      const privateOption = screen.getByText("プライベート");
+      fireEvent.click(privateOption);
+    });
 
-    fireEvent.change(tagInput, { target: { value: '買い物, 今日中' } })
-    fireEvent.click(addButton)
+    fireEvent.change(tagInput, { target: { value: "買い物, 今日中" } });
+    fireEvent.click(addButton);
 
     expect(mockOnSubmit).toHaveBeenCalledWith({
-      text: '完全なタスク',
-      categoryId: 'private',
-      tags: ['買い物', '今日中'],
-    })
-  })
+      text: "完全なタスク",
+      categoryId: "private",
+      tags: ["買い物", "今日中"],
+    });
+  });
 
   // 概要: 空のテキストでフォーム送信を試みてもコールバックが呼ばれないことを確認
   // 目的: 不正な入力での送信を防ぐことを保証
-  it('does not submit form with empty text', () => {
-    const mockOnSubmit = vi.fn()
+  it("does not submit form with empty text", () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const addButton = screen.getByRole('button', { name: /追加/i })
-    fireEvent.click(addButton)
+    const addButton = screen.getByRole("button", { name: /追加/i });
+    fireEvent.click(addButton);
 
-    expect(mockOnSubmit).not.toHaveBeenCalled()
-  })
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
 
   // 概要: フォーム送信後に入力フィールドがクリアされることを確認
   // 目的: ユーザーが連続してTodoを追加しやすくなることを保証
-  it('clears form after successful submission', async () => {
-    const mockOnSubmit = vi.fn()
+  it("clears form after successful submission", async () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
     const textInput = screen.getByPlaceholderText(
-      '新しいタスクを入力'
-    ) as HTMLInputElement
-    const tagInput = screen.getByLabelText('タグ') as HTMLInputElement
-    const addButton = screen.getByRole('button', { name: /追加/i })
+      "新しいタスクを入力",
+    ) as HTMLInputElement;
+    const tagInput = screen.getByLabelText("タグ") as HTMLInputElement;
+    const addButton = screen.getByRole("button", { name: /追加/i });
 
-    fireEvent.change(textInput, { target: { value: 'テストタスク' } })
-    fireEvent.change(tagInput, { target: { value: 'タグ1, タグ2' } })
-    fireEvent.click(addButton)
+    fireEvent.change(textInput, { target: { value: "テストタスク" } });
+    fireEvent.change(tagInput, { target: { value: "タグ1, タグ2" } });
+    fireEvent.click(addButton);
 
     await waitFor(() => {
-      expect(textInput.value).toBe('')
-      expect(tagInput.value).toBe('')
-    })
-  })
+      expect(textInput.value).toBe("");
+      expect(tagInput.value).toBe("");
+    });
+  });
 
   // 概要: カテゴリが空の配列の場合でもフォームが正常に動作することを確認
   // 目的: データの欠如時でもアプリケーションが安定動作することを保証
-  it('works with empty categories array', () => {
-    const mockOnSubmit = vi.fn()
+  it("works with empty categories array", () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={[]} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={[]} />);
 
-    const textInput = screen.getByPlaceholderText('新しいタスクを入力')
-    expect(textInput).toBeInTheDocument()
+    const textInput = screen.getByPlaceholderText("新しいタスクを入力");
+    expect(textInput).toBeInTheDocument();
 
-    const categorySelect = screen.getByLabelText('カテゴリ')
-    expect(categorySelect).toBeInTheDocument()
-  })
+    const categorySelect = screen.getByLabelText("カテゴリ");
+    expect(categorySelect).toBeInTheDocument();
+  });
 
   // 概要: Enterキーでフォームを送信できることを確認
   // 目的: キーボードショートカットでの送信が動作することを保証
-  it('submits form when Enter is pressed in text field', () => {
-    const mockOnSubmit = vi.fn()
+  it("submits form when Enter is pressed in text field", () => {
+    const mockOnSubmit = vi.fn();
 
-    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />)
+    render(<TodoForm onSubmit={mockOnSubmit} categories={mockCategories} />);
 
-    const textInput = screen.getByPlaceholderText('新しいタスクを入力')
+    const textInput = screen.getByPlaceholderText("新しいタスクを入力");
 
-    fireEvent.change(textInput, { target: { value: 'Enterテスト' } })
-    fireEvent.keyPress(textInput, { key: 'Enter', code: 'Enter', charCode: 13 })
+    fireEvent.change(textInput, { target: { value: "Enterテスト" } });
+    fireEvent.keyPress(textInput, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+    });
 
     expect(mockOnSubmit).toHaveBeenCalledWith({
-      text: 'Enterテスト',
+      text: "Enterテスト",
       categoryId: undefined,
       tags: [],
-    })
-  })
-})
+    });
+  });
+});

--- a/frontend/__tests__/components/TodoItem.test.tsx
+++ b/frontend/__tests__/components/TodoItem.test.tsx
@@ -1,173 +1,173 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import { TodoItem } from '../../src/components/TodoItem'
-import type { Todo } from '../../src/types/todo'
-import type { Category } from '../../src/types/category'
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TodoItem } from "../../src/components/TodoItem";
+import type { Todo } from "../../src/types/todo";
+import type { Category } from "../../src/types/category";
 
 const mockTodo: Todo = {
-  id: '1',
-  text: 'Test Todo',
+  id: "1",
+  text: "Test Todo",
   completed: false,
-  createdAt: new Date('2023-01-01'),
+  createdAt: new Date("2023-01-01"),
   categoryId: undefined,
   tags: [],
   order: 0,
-}
+};
 
 const mockCategories: Category[] = [
-  { id: 'work', name: '仕事', color: '#1976d2' },
-  { id: 'private', name: 'プライベート', color: '#ff5722' },
-]
+  { id: "work", name: "仕事", color: "#1976d2" },
+  { id: "private", name: "プライベート", color: "#ff5722" },
+];
 
 const mockTodoWithCategory: Todo = {
-  id: '2',
-  text: 'Work Todo',
+  id: "2",
+  text: "Work Todo",
   completed: false,
-  createdAt: new Date('2023-01-01'),
-  categoryId: 'work',
+  createdAt: new Date("2023-01-01"),
+  categoryId: "work",
   tags: [],
   order: 1,
-}
+};
 
 const mockTodoWithTags: Todo = {
-  id: '3',
-  text: 'Tagged Todo',
+  id: "3",
+  text: "Tagged Todo",
   completed: false,
-  createdAt: new Date('2023-01-01'),
+  createdAt: new Date("2023-01-01"),
   categoryId: undefined,
-  tags: ['重要', '急ぎ'],
+  tags: ["重要", "急ぎ"],
   order: 2,
-}
+};
 
 const mockTodoWithCategoryAndTags: Todo = {
-  id: '4',
-  text: 'Full Todo',
+  id: "4",
+  text: "Full Todo",
   completed: false,
-  createdAt: new Date('2023-01-01'),
-  categoryId: 'private',
-  tags: ['買い物', '今日中'],
+  createdAt: new Date("2023-01-01"),
+  categoryId: "private",
+  tags: ["買い物", "今日中"],
   order: 3,
-}
+};
 
-describe('TodoItem', () => {
+describe("TodoItem", () => {
   // 概要: Todoのテキストが正しく表示されることを確認
   // 目的: TodoItemコンポーネントが基本的なデータを正しく表示することを保証
-  it('renders todo text', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("renders todo text", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText('Test Todo')).toBeInTheDocument()
-  })
+    expect(screen.getByText("Test Todo")).toBeInTheDocument();
+  });
 
   // 概要: チェックボックスが正しい状態で表示されることを確認
   // 目的: Todo完了状態の視覚的フィードバックが正しく表示されることを保証
-  it('renders checkbox with correct checked state', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("renders checkbox with correct checked state", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
-      />
-    )
+      />,
+    );
 
-    const checkbox = screen.getByRole('checkbox')
-    expect(checkbox).not.toBeChecked()
-  })
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+  });
 
   // 概要: 完了済みTodoのチェックボックスがチェック状態で表示されることを確認
   // 目的: 完了済みTodoの視覚的状態が正しく反映されることを保証
-  it('renders checked checkbox for completed todo', () => {
-    const completedTodo = { ...mockTodo, completed: true }
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("renders checked checkbox for completed todo", () => {
+    const completedTodo = { ...mockTodo, completed: true };
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
         todo={completedTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
-      />
-    )
+      />,
+    );
 
-    const checkbox = screen.getByRole('checkbox')
-    expect(checkbox).toBeChecked()
-  })
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+  });
 
   // 概要: チェックボックスクリック時にonToggleコールバックが呼ばれることを確認
   // 目的: TodoItemからの状態変更イベントが正しく親コンポーネントに伝達されることを保証
-  it('calls onToggle when checkbox is clicked', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("calls onToggle when checkbox is clicked", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
-      />
-    )
+      />,
+    );
 
-    const checkbox = screen.getByRole('checkbox')
-    fireEvent.click(checkbox)
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
 
-    expect(mockOnToggle).toHaveBeenCalledWith('1')
-  })
+    expect(mockOnToggle).toHaveBeenCalledWith("1");
+  });
 
   // 概要: 削除ボタンクリック時にonDeleteコールバックが呼ばれることを確認
   // 目的: TodoItemからの削除イベントが正しく親コンポーネントに伝達されることを保証
-  it('calls onDelete when delete button is clicked', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("calls onDelete when delete button is clicked", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
-      />
-    )
+      />,
+    );
 
-    const deleteButton = screen.getByRole('button', { name: /delete/i })
-    fireEvent.click(deleteButton)
+    const deleteButton = screen.getByRole("button", { name: /delete/i });
+    fireEvent.click(deleteButton);
 
-    expect(mockOnDelete).toHaveBeenCalledWith('1')
-  })
+    expect(mockOnDelete).toHaveBeenCalledWith("1");
+  });
 
   // 概要: 完了済みTodoのテキストに取り消し線が適用されることを確認
   // 目的: 完了済みTodoの視覚的フィードバックが適切に提供されることを保証
-  it('applies strikethrough style to completed todo text', () => {
-    const completedTodo = { ...mockTodo, completed: true }
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("applies strikethrough style to completed todo text", () => {
+    const completedTodo = { ...mockTodo, completed: true };
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
         todo={completedTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
-      />
-    )
+      />,
+    );
 
-    const todoText = screen.getByText('Test Todo')
-    expect(todoText).toHaveStyle('text-decoration: line-through')
-  })
+    const todoText = screen.getByText("Test Todo");
+    expect(todoText).toHaveStyle("text-decoration: line-through");
+  });
 
   // 概要: カテゴリが設定されたTodoでカテゴリChipが表示されることを確認
   // 目的: カテゴリ情報が適切に視覚化されることを保証
-  it('displays category chip when todo has category', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("displays category chip when todo has category", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
@@ -175,18 +175,18 @@ describe('TodoItem', () => {
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const categoryChip = screen.getByText('仕事')
-    expect(categoryChip).toBeInTheDocument()
-  })
+    const categoryChip = screen.getByText("仕事");
+    expect(categoryChip).toBeInTheDocument();
+  });
 
   // 概要: カテゴリが設定されていないTodoでカテゴリChipが表示されないことを確認
   // 目的: カテゴリなしのTodoで不要なUIが表示されないことを保証
-  it('does not display category chip when todo has no category', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("does not display category chip when todo has no category", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
@@ -194,18 +194,18 @@ describe('TodoItem', () => {
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const categoryChip = screen.queryByText('仕事')
-    expect(categoryChip).not.toBeInTheDocument()
-  })
+    const categoryChip = screen.queryByText("仕事");
+    expect(categoryChip).not.toBeInTheDocument();
+  });
 
   // 概要: タグが設定されたTodoでタグChipが表示されることを確認
   // 目的: タグ情報が適切に視覚化されることを保証
-  it('displays tag chips when todo has tags', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("displays tag chips when todo has tags", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
@@ -213,21 +213,21 @@ describe('TodoItem', () => {
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const importantTag = screen.getByText('重要')
-    const urgentTag = screen.getByText('急ぎ')
+    const importantTag = screen.getByText("重要");
+    const urgentTag = screen.getByText("急ぎ");
 
-    expect(importantTag).toBeInTheDocument()
-    expect(urgentTag).toBeInTheDocument()
-  })
+    expect(importantTag).toBeInTheDocument();
+    expect(urgentTag).toBeInTheDocument();
+  });
 
   // 概要: タグが設定されていないTodoでタグChipが表示されないことを確認
   // 目的: タグなしのTodoで不要なUIが表示されないことを保証
-  it('does not display tag chips when todo has no tags', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("does not display tag chips when todo has no tags", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
@@ -235,18 +235,18 @@ describe('TodoItem', () => {
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const tagContainer = screen.queryByTestId('tags-container')
-    expect(tagContainer).not.toBeInTheDocument()
-  })
+    const tagContainer = screen.queryByTestId("tags-container");
+    expect(tagContainer).not.toBeInTheDocument();
+  });
 
   // 概要: カテゴリとタグの両方が設定されたTodoで両方が表示されることを確認
   // 目的: 複数の分類情報が適切に同時表示されることを保証
-  it('displays both category and tag chips when todo has both', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("displays both category and tag chips when todo has both", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
@@ -254,24 +254,24 @@ describe('TodoItem', () => {
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const categoryChip = screen.getByText('プライベート')
-    const shoppingTag = screen.getByText('買い物')
-    const todayTag = screen.getByText('今日中')
+    const categoryChip = screen.getByText("プライベート");
+    const shoppingTag = screen.getByText("買い物");
+    const todayTag = screen.getByText("今日中");
 
-    expect(categoryChip).toBeInTheDocument()
-    expect(shoppingTag).toBeInTheDocument()
-    expect(todayTag).toBeInTheDocument()
-  })
+    expect(categoryChip).toBeInTheDocument();
+    expect(shoppingTag).toBeInTheDocument();
+    expect(todayTag).toBeInTheDocument();
+  });
 
   // 概要: 存在しないカテゴリIDの場合にエラーが発生しないことを確認
   // 目的: データの整合性が取れない場合でもアプリケーションが安定して動作することを保証
-  it('handles invalid category id gracefully', () => {
-    const todoWithInvalidCategory = { ...mockTodo, categoryId: 'invalid-id' }
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("handles invalid category id gracefully", () => {
+    const todoWithInvalidCategory = { ...mockTodo, categoryId: "invalid-id" };
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     expect(() => {
       render(
@@ -280,41 +280,41 @@ describe('TodoItem', () => {
           onToggle={mockOnToggle}
           onDelete={mockOnDelete}
           categories={mockCategories}
-        />
-      )
-    }).not.toThrow()
+        />,
+      );
+    }).not.toThrow();
 
     // 無効なカテゴリIDの場合はカテゴリChipが表示されない
-    const invalidCategoryChip = screen.queryByText('invalid-id')
-    expect(invalidCategoryChip).not.toBeInTheDocument()
-  })
+    const invalidCategoryChip = screen.queryByText("invalid-id");
+    expect(invalidCategoryChip).not.toBeInTheDocument();
+  });
 
   // 概要: 編集機能なしでも正常に動作することをテスト
   // 目的: onEditプロパティがない場合でも後方互換性を保つことを保証
-  it('renders without edit functionality when onEdit is not provided', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
+  it("renders without edit functionality when onEdit is not provided", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
 
     render(
       <TodoItem
         todo={mockTodo}
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByText('Test Todo')).toBeInTheDocument()
+    expect(screen.getByText("Test Todo")).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /編集|edit/i })
-    ).not.toBeInTheDocument()
-  })
+      screen.queryByRole("button", { name: /編集|edit/i }),
+    ).not.toBeInTheDocument();
+  });
 
   // 概要: onEditが提供された場合に編集ボタンが表示されることをテスト
   // 目的: 編集機能が有効な場合に適切なUIが表示されることを保証
-  it('renders edit button when onEdit is provided', () => {
-    const mockOnToggle = vi.fn()
-    const mockOnDelete = vi.fn()
-    const mockOnEdit = vi.fn()
+  it("renders edit button when onEdit is provided", () => {
+    const mockOnToggle = vi.fn();
+    const mockOnDelete = vi.fn();
+    const mockOnEdit = vi.fn();
 
     render(
       <TodoItem
@@ -322,9 +322,9 @@ describe('TodoItem', () => {
         onToggle={mockOnToggle}
         onDelete={mockOnDelete}
         onEdit={mockOnEdit}
-      />
-    )
+      />,
+    );
 
-    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument()
-  })
-})
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/TodoItemWithEdit.test.tsx
+++ b/frontend/__tests__/components/TodoItemWithEdit.test.tsx
@@ -1,31 +1,31 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import { TodoItem } from '../../src/components/TodoItem'
-import type { Todo } from '../../src/types/todo'
-import type { Category } from '../../src/types/category'
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TodoItem } from "../../src/components/TodoItem";
+import type { Todo } from "../../src/types/todo";
+import type { Category } from "../../src/types/category";
 
 const mockTodo: Todo = {
-  id: '1',
-  text: 'Test Todo',
+  id: "1",
+  text: "Test Todo",
   completed: false,
-  createdAt: new Date('2023-01-01'),
-  categoryId: 'cat1',
-  tags: ['tag1', 'tag2'],
+  createdAt: new Date("2023-01-01"),
+  categoryId: "cat1",
+  tags: ["tag1", "tag2"],
   order: 0,
-}
+};
 
 const mockCategories: Category[] = [
-  { id: 'cat1', name: '仕事', color: '#2196f3' },
-  { id: 'cat2', name: '個人', color: '#4caf50' },
-]
+  { id: "cat1", name: "仕事", color: "#2196f3" },
+  { id: "cat2", name: "個人", color: "#4caf50" },
+];
 
-describe('TodoItem with Edit functionality', () => {
+describe("TodoItem with Edit functionality", () => {
   // 概要: 編集ボタンが表示されることをテスト
   // 目的: TodoItemに編集ボタンが正しく表示されることを保証
-  it('renders edit button', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("renders edit button", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -34,19 +34,19 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const editButton = screen.getByRole('button', { name: /編集|edit/i })
-    expect(editButton).toBeInTheDocument()
-  })
+    const editButton = screen.getByRole("button", { name: /編集|edit/i });
+    expect(editButton).toBeInTheDocument();
+  });
 
   // 概要: 編集ボタンクリックで編集モードに入ることをテスト
   // 目的: 編集ボタンをクリックした際に編集フォームが表示されることを保証
-  it('enters edit mode when edit button is clicked', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("enters edit mode when edit button is clicked", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -55,27 +55,27 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const editButton = screen.getByRole('button', { name: /編集|edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /編集|edit/i });
+    fireEvent.click(editButton);
 
     // 編集モードでは保存・キャンセルボタンが表示される
     expect(
-      screen.getByRole('button', { name: /保存|save/i })
-    ).toBeInTheDocument()
+      screen.getByRole("button", { name: /保存|save/i }),
+    ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /キャンセル|cancel/i })
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("button", { name: /キャンセル|cancel/i }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: ダブルクリックで編集モードに入ることをテスト
   // 目的: TodoItemをダブルクリックした際に編集フォームが表示されることを保証
-  it('enters edit mode when double-clicked', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("enters edit mode when double-clicked", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -84,27 +84,27 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const todoText = screen.getByText('Test Todo')
-    fireEvent.doubleClick(todoText)
+    const todoText = screen.getByText("Test Todo");
+    fireEvent.doubleClick(todoText);
 
     // 編集モードでは保存・キャンセルボタンが表示される
     expect(
-      screen.getByRole('button', { name: /保存|save/i })
-    ).toBeInTheDocument()
+      screen.getByRole("button", { name: /保存|save/i }),
+    ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /キャンセル|cancel/i })
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("button", { name: /キャンセル|cancel/i }),
+    ).toBeInTheDocument();
+  });
 
   // 概要: 編集モードでテキストが編集フィールドに表示されることをテスト
   // 目的: 編集モードに入った際に現在のTodoテキストが編集フィールドに表示されることを保証
-  it('shows todo text in edit field when in edit mode', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("shows todo text in edit field when in edit mode", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -113,21 +113,21 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
-    const editButton = screen.getByRole('button', { name: /編集|edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /編集|edit/i });
+    fireEvent.click(editButton);
 
-    expect(screen.getByDisplayValue('Test Todo')).toBeInTheDocument()
-  })
+    expect(screen.getByDisplayValue("Test Todo")).toBeInTheDocument();
+  });
 
   // 概要: 編集保存でonEditが呼ばれることをテスト
   // 目的: 編集内容を保存した際にonEditコールバックが正しいデータで呼ばれることを保証
-  it('calls onEdit when edit is saved', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("calls onEdit when edit is saved", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -136,34 +136,34 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
     // 編集モードに入る
-    const editButton = screen.getByRole('button', { name: /編集|edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /編集|edit/i });
+    fireEvent.click(editButton);
 
     // テキストを変更
-    const textInput = screen.getByDisplayValue('Test Todo')
-    fireEvent.change(textInput, { target: { value: 'Updated Todo' } })
+    const textInput = screen.getByDisplayValue("Test Todo");
+    fireEvent.change(textInput, { target: { value: "Updated Todo" } });
 
     // 保存ボタンをクリック
-    const saveButton = screen.getByRole('button', { name: /保存|save/i })
-    fireEvent.click(saveButton)
+    const saveButton = screen.getByRole("button", { name: /保存|save/i });
+    fireEvent.click(saveButton);
 
-    expect(onEdit).toHaveBeenCalledWith('1', {
-      text: 'Updated Todo',
-      categoryId: 'cat1',
-      tags: ['tag1', 'tag2'],
-    })
-  })
+    expect(onEdit).toHaveBeenCalledWith("1", {
+      text: "Updated Todo",
+      categoryId: "cat1",
+      tags: ["tag1", "tag2"],
+    });
+  });
 
   // 概要: 編集キャンセルで元の表示に戻ることをテスト
   // 目的: 編集をキャンセルした際に元のTodoアイテム表示に戻ることを保証
-  it('returns to normal view when edit is cancelled', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("returns to normal view when edit is cancelled", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -172,39 +172,39 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
     // 編集モードに入る
-    const editButton = screen.getByRole('button', { name: /編集|edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /編集|edit/i });
+    fireEvent.click(editButton);
 
     // テキストを変更
-    const textInput = screen.getByDisplayValue('Test Todo')
-    fireEvent.change(textInput, { target: { value: 'Updated Todo' } })
+    const textInput = screen.getByDisplayValue("Test Todo");
+    fireEvent.change(textInput, { target: { value: "Updated Todo" } });
 
     // キャンセルボタンをクリック
-    const cancelButton = screen.getByRole('button', {
+    const cancelButton = screen.getByRole("button", {
       name: /キャンセル|cancel/i,
-    })
-    fireEvent.click(cancelButton)
+    });
+    fireEvent.click(cancelButton);
 
     // 元のテキストが表示されている
-    expect(screen.getByText('Test Todo')).toBeInTheDocument()
+    expect(screen.getByText("Test Todo")).toBeInTheDocument();
     // 編集ボタンが再び表示されている
     expect(
-      screen.getByRole('button', { name: /編集|edit/i })
-    ).toBeInTheDocument()
+      screen.getByRole("button", { name: /編集|edit/i }),
+    ).toBeInTheDocument();
     // onEditは呼ばれていない
-    expect(onEdit).not.toHaveBeenCalled()
-  })
+    expect(onEdit).not.toHaveBeenCalled();
+  });
 
   // 概要: Enterキーで編集保存されることをテスト
   // 目的: 編集フィールドでEnterキーを押した際に編集内容が保存されることを保証
-  it('saves edit when Enter key is pressed', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("saves edit when Enter key is pressed", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -213,31 +213,35 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
     // 編集モードに入る
-    const editButton = screen.getByRole('button', { name: /編集|edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /編集|edit/i });
+    fireEvent.click(editButton);
 
     // テキストを変更してEnterキーを押す
-    const textInput = screen.getByDisplayValue('Test Todo')
-    fireEvent.change(textInput, { target: { value: 'Enter saved Todo' } })
-    fireEvent.keyPress(textInput, { key: 'Enter', code: 'Enter', charCode: 13 })
+    const textInput = screen.getByDisplayValue("Test Todo");
+    fireEvent.change(textInput, { target: { value: "Enter saved Todo" } });
+    fireEvent.keyPress(textInput, {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+    });
 
-    expect(onEdit).toHaveBeenCalledWith('1', {
-      text: 'Enter saved Todo',
-      categoryId: 'cat1',
-      tags: ['tag1', 'tag2'],
-    })
-  })
+    expect(onEdit).toHaveBeenCalledWith("1", {
+      text: "Enter saved Todo",
+      categoryId: "cat1",
+      tags: ["tag1", "tag2"],
+    });
+  });
 
   // 概要: Escapeキーで編集キャンセルされることをテスト
   // 目的: 編集フィールドでEscapeキーを押した際に編集がキャンセルされることを保証
-  it('cancels edit when Escape key is pressed', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("cancels edit when Escape key is pressed", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -246,30 +250,30 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
     // 編集モードに入る
-    const editButton = screen.getByRole('button', { name: /編集|edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /編集|edit/i });
+    fireEvent.click(editButton);
 
     // テキストを変更してEscapeキーを押す
-    const textInput = screen.getByDisplayValue('Test Todo')
-    fireEvent.change(textInput, { target: { value: 'Escape cancelled Todo' } })
-    fireEvent.keyDown(textInput, { key: 'Escape', code: 'Escape' })
+    const textInput = screen.getByDisplayValue("Test Todo");
+    fireEvent.change(textInput, { target: { value: "Escape cancelled Todo" } });
+    fireEvent.keyDown(textInput, { key: "Escape", code: "Escape" });
 
     // 元のテキストが表示されている
-    expect(screen.getByText('Test Todo')).toBeInTheDocument()
+    expect(screen.getByText("Test Todo")).toBeInTheDocument();
     // onEditは呼ばれていない
-    expect(onEdit).not.toHaveBeenCalled()
-  })
+    expect(onEdit).not.toHaveBeenCalled();
+  });
 
   // 概要: 編集モードでは削除ボタンが非表示になることをテスト
   // 目的: 編集中は誤削除を防ぐため削除ボタンが非表示になることを保証
-  it('hides delete button in edit mode', () => {
-    const onToggle = vi.fn()
-    const onDelete = vi.fn()
-    const onEdit = vi.fn()
+  it("hides delete button in edit mode", () => {
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const onEdit = vi.fn();
 
     render(
       <TodoItem
@@ -278,19 +282,19 @@ describe('TodoItem with Edit functionality', () => {
         onDelete={onDelete}
         onEdit={onEdit}
         categories={mockCategories}
-      />
-    )
+      />,
+    );
 
     // 通常モードでは削除ボタンが表示されている
-    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
 
     // 編集モードに入る
-    const editButton = screen.getByRole('button', { name: /編集|edit/i })
-    fireEvent.click(editButton)
+    const editButton = screen.getByRole("button", { name: /編集|edit/i });
+    fireEvent.click(editButton);
 
     // 編集モードでは削除ボタンが非表示
     expect(
-      screen.queryByRole('button', { name: /delete/i })
-    ).not.toBeInTheDocument()
-  })
-})
+      screen.queryByRole("button", { name: /delete/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/e2e/category-management.spec.ts
+++ b/frontend/__tests__/e2e/category-management.spec.ts
@@ -1,307 +1,317 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from "@playwright/test";
 
-test.describe('Category Management E2E Tests', () => {
+test.describe("Category Management E2E Tests", () => {
   // 概要: ナビゲーション機能をテスト
   // 目的: Todo画面とカテゴリ管理画面間の遷移が正しく動作することを保証（Issue #5要件）
-  test('should navigate between Todo and Category pages', async ({ page }) => {
-    await page.goto('/')
+  test("should navigate between Todo and Category pages", async ({ page }) => {
+    await page.goto("/");
 
     // Todo画面の表示確認
-    await expect(page.getByRole('heading', { name: /todo app/i })).toBeVisible()
+    await expect(
+      page.getByRole("heading", { name: /todo app/i }),
+    ).toBeVisible();
 
     // ナビゲーションタブの存在確認
-    await expect(page.getByRole('tab', { name: 'Todo page' })).toBeVisible()
+    await expect(page.getByRole("tab", { name: "Todo page" })).toBeVisible();
     await expect(
-      page.getByRole('tab', { name: 'Categories management page' })
-    ).toBeVisible()
+      page.getByRole("tab", { name: "Categories management page" }),
+    ).toBeVisible();
 
     // カテゴリ管理タブをクリック
-    await page.getByRole('tab', { name: 'Categories management page' }).click()
+    await page.getByRole("tab", { name: "Categories management page" }).click();
 
     // URLが正しく変更されることを確認
-    await expect(page).toHaveURL('/categories')
+    await expect(page).toHaveURL("/categories");
 
     // カテゴリ管理画面の表示確認
     await expect(
-      page.getByRole('heading', { name: 'カテゴリ管理' })
-    ).toBeVisible()
+      page.getByRole("heading", { name: "カテゴリ管理" }),
+    ).toBeVisible();
 
     // Todoタブをクリック
-    await page.getByRole('tab', { name: 'Todo page' }).click()
+    await page.getByRole("tab", { name: "Todo page" }).click();
 
     // URLが正しく変更されることを確認
-    await expect(page).toHaveURL('/')
+    await expect(page).toHaveURL("/");
 
     // Todo画面に戻ることを確認
-    await expect(page.getByRole('heading', { name: /todo app/i })).toBeVisible()
-  })
+    await expect(
+      page.getByRole("heading", { name: /todo app/i }),
+    ).toBeVisible();
+  });
 
   // 概要: カテゴリ一覧画面の基本機能をテスト
   // 目的: カテゴリ一覧ページが正しく表示され、新規作成ボタンが動作することを保証（Issue #5要件）
-  test('should display categories list with new button', async ({ page }) => {
-    await page.goto('/categories')
+  test("should display categories list with new button", async ({ page }) => {
+    await page.goto("/categories");
 
     // ページタイトルの確認
     await expect(
-      page.getByRole('heading', { name: 'カテゴリ管理' })
-    ).toBeVisible()
+      page.getByRole("heading", { name: "カテゴリ管理" }),
+    ).toBeVisible();
 
     // 新規作成ボタンの確認
-    await expect(page.getByRole('button', { name: '新規作成' })).toBeVisible()
+    await expect(page.getByRole("button", { name: "新規作成" })).toBeVisible();
 
     // デフォルトカテゴリの表示確認
-    await expect(page.getByText('仕事').first()).toBeVisible()
-    await expect(page.getByText('プライベート').first()).toBeVisible()
-    await expect(page.getByText('その他').first()).toBeVisible()
+    await expect(page.getByText("仕事").first()).toBeVisible();
+    await expect(page.getByText("プライベート").first()).toBeVisible();
+    await expect(page.getByText("その他").first()).toBeVisible();
 
     // 各カテゴリの編集・削除ボタンの確認
-    const editButtons = page.getByRole('button', { name: '編集' })
-    const deleteButtons = page.getByRole('button', { name: '削除' })
+    const editButtons = page.getByRole("button", { name: "編集" });
+    const deleteButtons = page.getByRole("button", { name: "削除" });
 
-    await expect(editButtons).toHaveCount(3)
-    await expect(deleteButtons).toHaveCount(3)
-  })
+    await expect(editButtons).toHaveCount(3);
+    await expect(deleteButtons).toHaveCount(3);
+  });
 
   // 概要: 新規カテゴリ作成フォームへの遷移をテスト
   // 目的: 新規作成ボタンから作成フォームに正しく遷移できることを保証（Issue #5要件）
-  test('should navigate to new category form', async ({ page }) => {
-    await page.goto('/categories')
+  test("should navigate to new category form", async ({ page }) => {
+    await page.goto("/categories");
 
     // 新規作成ボタンをクリック
-    await page.getByRole('button', { name: '新規作成' }).click()
+    await page.getByRole("button", { name: "新規作成" }).click();
 
     // URLが正しく変更されることを確認
-    await expect(page).toHaveURL('/categories/new')
+    await expect(page).toHaveURL("/categories/new");
 
     // フォームの表示確認
-    await expect(page.getByText('カテゴリ新規作成')).toBeVisible()
-    await expect(page.getByLabel('カテゴリ名')).toBeVisible()
-    await expect(page.getByLabel('色')).toBeVisible()
-    await expect(page.getByLabel('説明')).toBeVisible()
-    await expect(page.getByRole('button', { name: '作成' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'キャンセル' })).toBeVisible()
-  })
+    await expect(page.getByText("カテゴリ新規作成")).toBeVisible();
+    await expect(page.getByLabel("カテゴリ名")).toBeVisible();
+    await expect(page.getByLabel("色")).toBeVisible();
+    await expect(page.getByLabel("説明")).toBeVisible();
+    await expect(page.getByRole("button", { name: "作成" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "キャンセル" }),
+    ).toBeVisible();
+  });
 
   // 概要: 新規カテゴリ作成機能をテスト
   // 目的: カテゴリ作成フォームで新しいカテゴリを作成できることを保証（Issue #5要件）
-  test('should create new category', async ({ page }) => {
-    await page.goto('/categories/new')
+  test("should create new category", async ({ page }) => {
+    await page.goto("/categories/new");
 
     // フォームに入力
-    await page.getByLabel('カテゴリ名').fill('学習')
-    await page.getByLabel('色').fill('#4caf50')
-    await page.getByLabel('説明').fill('学習関連のタスク')
+    await page.getByLabel("カテゴリ名").fill("学習");
+    await page.getByLabel("色").fill("#4caf50");
+    await page.getByLabel("説明").fill("学習関連のタスク");
 
     // 作成ボタンをクリック
-    await page.getByRole('button', { name: '作成' }).click()
+    await page.getByRole("button", { name: "作成" }).click();
 
     // カテゴリ一覧に戻ることを確認
-    await expect(page).toHaveURL('/categories')
+    await expect(page).toHaveURL("/categories");
 
     // 新しいカテゴリが表示されることを確認
-    await expect(page.getByText('学習').first()).toBeVisible()
-  })
+    await expect(page.getByText("学習").first()).toBeVisible();
+  });
 
   // Note: 詳細なバリデーションエラーメッセージのテストは単体テストで実施済み
   // E2Eではバリデーションエラー時の画面遷移制御のみをテスト
-  test('should prevent navigation when validation fails', async ({ page }) => {
-    await page.goto('/categories/new')
+  test("should prevent navigation when validation fails", async ({ page }) => {
+    await page.goto("/categories/new");
 
     // 空の状態で作成ボタンをクリック
-    await page.getByRole('button', { name: '作成' }).click()
+    await page.getByRole("button", { name: "作成" }).click();
 
     // URLが変わらないことを確認（バリデーションエラーで作成に失敗）
-    await expect(page).toHaveURL('/categories/new')
-  })
+    await expect(page).toHaveURL("/categories/new");
+  });
 
   // 概要: カテゴリ作成のキャンセル機能をテスト
   // 目的: キャンセルボタンでカテゴリ一覧に戻れることを保証（Issue #5要件）
-  test('should cancel category creation', async ({ page }) => {
-    await page.goto('/categories/new')
+  test("should cancel category creation", async ({ page }) => {
+    await page.goto("/categories/new");
 
     // フォームに入力
-    await page.getByLabel('カテゴリ名').fill('テストカテゴリ')
+    await page.getByLabel("カテゴリ名").fill("テストカテゴリ");
 
     // キャンセルボタンをクリック
-    await page.getByRole('button', { name: 'キャンセル' }).click()
+    await page.getByRole("button", { name: "キャンセル" }).click();
 
     // カテゴリ一覧に戻ることを確認
-    await expect(page).toHaveURL('/categories')
+    await expect(page).toHaveURL("/categories");
 
     // 入力したカテゴリが作成されていないことを確認
-    await expect(page.getByText('テストカテゴリ')).not.toBeVisible()
-  })
+    await expect(page.getByText("テストカテゴリ")).not.toBeVisible();
+  });
 
   // 概要: カテゴリ編集フォームへの遷移をテスト
   // 目的: 編集ボタンから編集フォームに正しく遷移できることを保証（Issue #5要件）
-  test('should navigate to edit category form', async ({ page }) => {
-    await page.goto('/categories')
+  test("should navigate to edit category form", async ({ page }) => {
+    await page.goto("/categories");
 
     // 最初のカテゴリの編集ボタンをクリック
-    const editButtons = page.getByRole('button', { name: '編集' })
-    await editButtons.first().click()
+    const editButtons = page.getByRole("button", { name: "編集" });
+    await editButtons.first().click();
 
     // URLが正しく変更されることを確認（work カテゴリの編集）
-    await expect(page).toHaveURL('/categories/work/edit')
+    await expect(page).toHaveURL("/categories/work/edit");
 
     // 編集フォームの表示確認
-    await expect(page.getByText('カテゴリ編集')).toBeVisible()
-    await expect(page.getByLabel('カテゴリ名')).toHaveValue('仕事')
-    await expect(page.getByRole('button', { name: '更新' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'キャンセル' })).toBeVisible()
-  })
+    await expect(page.getByText("カテゴリ編集")).toBeVisible();
+    await expect(page.getByLabel("カテゴリ名")).toHaveValue("仕事");
+    await expect(page.getByRole("button", { name: "更新" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "キャンセル" }),
+    ).toBeVisible();
+  });
 
   // 概要: カテゴリ編集機能をテスト
   // 目的: カテゴリ編集フォームで既存カテゴリを更新できることを保証（Issue #5要件）
-  test('should edit existing category', async ({ page }) => {
-    await page.goto('/categories/work/edit')
+  test("should edit existing category", async ({ page }) => {
+    await page.goto("/categories/work/edit");
 
     // フォーム内容の確認
-    await expect(page.getByLabel('カテゴリ名')).toHaveValue('仕事')
+    await expect(page.getByLabel("カテゴリ名")).toHaveValue("仕事");
 
     // フォームを更新
-    await page.getByLabel('カテゴリ名').fill('ビジネス')
-    await page.getByLabel('説明').fill('ビジネス関連のタスク')
+    await page.getByLabel("カテゴリ名").fill("ビジネス");
+    await page.getByLabel("説明").fill("ビジネス関連のタスク");
 
     // 更新ボタンをクリック
-    await page.getByRole('button', { name: '更新' }).click()
+    await page.getByRole("button", { name: "更新" }).click();
 
     // カテゴリ一覧に戻ることを確認
-    await expect(page).toHaveURL('/categories')
+    await expect(page).toHaveURL("/categories");
 
     // 更新されたカテゴリが表示されることを確認
-    await expect(page.getByText('ビジネス').first()).toBeVisible()
-  })
+    await expect(page.getByText("ビジネス").first()).toBeVisible();
+  });
 
   // 概要: カテゴリ編集のキャンセル機能をテスト
   // 目的: 編集キャンセルボタンでカテゴリ一覧に戻れることを保証（Issue #5要件）
-  test('should cancel category editing', async ({ page }) => {
-    await page.goto('/categories/private/edit')
+  test("should cancel category editing", async ({ page }) => {
+    await page.goto("/categories/private/edit");
 
     // フォーム内容を変更
-    await page.getByLabel('カテゴリ名').fill('変更されたプライベート')
+    await page.getByLabel("カテゴリ名").fill("変更されたプライベート");
 
     // キャンセルボタンをクリック
-    await page.getByRole('button', { name: 'キャンセル' }).click()
+    await page.getByRole("button", { name: "キャンセル" }).click();
 
     // カテゴリ一覧に戻ることを確認
-    await expect(page).toHaveURL('/categories')
+    await expect(page).toHaveURL("/categories");
 
     // 元のカテゴリ名が保持されていることを確認
-    await expect(page.getByText('プライベート')).toBeVisible()
-    await expect(page.getByText('変更されたプライベート')).not.toBeVisible()
-  })
+    await expect(page.getByText("プライベート")).toBeVisible();
+    await expect(page.getByText("変更されたプライベート")).not.toBeVisible();
+  });
 
   // 概要: カテゴリ削除機能をテスト
   // 目的: 削除ボタンで確認ダイアログが表示され、削除が実行されることを保証（Issue #5要件）
-  test('should delete category with confirmation', async ({ page }) => {
-    await page.goto('/categories')
+  test("should delete category with confirmation", async ({ page }) => {
+    await page.goto("/categories");
 
     // 「その他」カテゴリを削除（使用されていないため削除可能）
-    const deleteButtons = page.getByRole('button', { name: '削除' })
+    const deleteButtons = page.getByRole("button", { name: "削除" });
 
     // 削除前にカテゴリが存在することを確認
-    await expect(page.getByText('その他').first()).toBeVisible()
+    await expect(page.getByText("その他").first()).toBeVisible();
 
     // ダイアログハンドラーを設定
-    page.on('dialog', async dialog => {
-      expect(dialog.message()).toBe('このカテゴリを削除しますか？')
-      await dialog.accept()
-    })
+    page.on("dialog", async (dialog) => {
+      expect(dialog.message()).toBe("このカテゴリを削除しますか？");
+      await dialog.accept();
+    });
 
     // 最後の削除ボタン（その他カテゴリ）をクリック
-    await deleteButtons.last().click()
+    await deleteButtons.last().click();
 
     // カテゴリが削除されることを確認
-    await expect(page.getByText('その他').first()).not.toBeVisible()
-  })
+    await expect(page.getByText("その他").first()).not.toBeVisible();
+  });
 
   // 概要: 存在しないカテゴリIDでのアクセスをテスト
   // 目的: 無効なカテゴリIDで編集ページにアクセスした場合の動作を保証（Issue #5要件）
-  test('should handle invalid category ID in edit route', async ({ page }) => {
-    await page.goto('/categories/invalid-id/edit')
+  test("should handle invalid category ID in edit route", async ({ page }) => {
+    await page.goto("/categories/invalid-id/edit");
 
     // エラーメッセージが表示されることを確認
-    await expect(page.getByText('カテゴリが見つかりません')).toBeVisible()
+    await expect(page.getByText("カテゴリが見つかりません")).toBeVisible();
 
     // URLは変わらない（エラーページが表示される）
-    await expect(page).toHaveURL('/categories/invalid-id/edit')
-  })
+    await expect(page).toHaveURL("/categories/invalid-id/edit");
+  });
 
   // 概要: 404ページの表示をテスト
   // 目的: 存在しないパスにアクセスした場合に404ページが表示されることを保証（Issue #5要件）
-  test('should display 404 page for invalid routes', async ({ page }) => {
-    await page.goto('/invalid-path')
+  test("should display 404 page for invalid routes", async ({ page }) => {
+    await page.goto("/invalid-path");
 
     // 404ページの表示確認
-    await expect(page.getByText('404')).toBeVisible()
-    await expect(page.getByText('ページが見つかりません')).toBeVisible()
+    await expect(page.getByText("404")).toBeVisible();
+    await expect(page.getByText("ページが見つかりません")).toBeVisible();
 
     // ナビゲーションボタンの確認
     await expect(
-      page.getByRole('button', { name: 'ホームに戻る' })
-    ).toBeVisible()
+      page.getByRole("button", { name: "ホームに戻る" }),
+    ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: 'カテゴリ管理に戻る' })
-    ).toBeVisible()
-  })
+      page.getByRole("button", { name: "カテゴリ管理に戻る" }),
+    ).toBeVisible();
+  });
 
   // 概要: 404ページからのナビゲーションをテスト
   // 目的: 404ページのナビゲーションボタンが正しく動作することを保証（Issue #5要件）
-  test('should navigate from 404 page', async ({ page }) => {
-    await page.goto('/invalid-path')
+  test("should navigate from 404 page", async ({ page }) => {
+    await page.goto("/invalid-path");
 
     // ホームに戻るボタンをクリック
-    await page.getByRole('button', { name: 'ホームに戻る' }).click()
+    await page.getByRole("button", { name: "ホームに戻る" }).click();
 
     // ホームページに遷移することを確認
-    await expect(page).toHaveURL('/')
-    await expect(page.getByRole('heading', { name: /todo app/i })).toBeVisible()
+    await expect(page).toHaveURL("/");
+    await expect(
+      page.getByRole("heading", { name: /todo app/i }),
+    ).toBeVisible();
 
     // 再度404ページに移動
-    await page.goto('/another-invalid-path')
+    await page.goto("/another-invalid-path");
 
     // カテゴリ管理に戻るボタンをクリック
-    await page.getByRole('button', { name: 'カテゴリ管理に戻る' }).click()
+    await page.getByRole("button", { name: "カテゴリ管理に戻る" }).click();
 
     // カテゴリ管理ページに遷移することを確認
-    await expect(page).toHaveURL('/categories')
+    await expect(page).toHaveURL("/categories");
     await expect(
-      page.getByRole('heading', { name: 'カテゴリ管理' })
-    ).toBeVisible()
-  })
+      page.getByRole("heading", { name: "カテゴリ管理" }),
+    ).toBeVisible();
+  });
 
   // 概要: カテゴリ管理とTodo機能の統合をテスト
   // 目的: 新しく作成したカテゴリがTodo作成フォームで利用できることを保証（Issue #5要件）
-  test('should integrate new category with todo creation', async ({ page }) => {
+  test("should integrate new category with todo creation", async ({ page }) => {
     // 新しいカテゴリを作成
-    await page.goto('/categories/new')
+    await page.goto("/categories/new");
 
-    await page.getByLabel('カテゴリ名').fill('テスト統合')
-    await page.getByLabel('色').fill('#9c27b0')
-    await page.getByLabel('説明').fill('統合テスト用')
-    await page.getByRole('button', { name: '作成' }).click()
+    await page.getByLabel("カテゴリ名").fill("テスト統合");
+    await page.getByLabel("色").fill("#9c27b0");
+    await page.getByLabel("説明").fill("統合テスト用");
+    await page.getByRole("button", { name: "作成" }).click();
 
     // Todo画面に移動
-    await page.getByRole('tab', { name: 'Todo page' }).click()
-    await expect(page).toHaveURL('/')
+    await page.getByRole("tab", { name: "Todo page" }).click();
+    await expect(page).toHaveURL("/");
 
     // カテゴリセレクトで新しいカテゴリが選択できることを確認
-    const categorySelect = page.getByLabel('カテゴリ').first()
-    await categorySelect.click()
+    const categorySelect = page.getByLabel("カテゴリ").first();
+    await categorySelect.click();
 
     // 新しく作成したカテゴリが選択肢に含まれることを確認
-    await expect(page.getByText('テスト統合')).toBeVisible()
+    await expect(page.getByText("テスト統合")).toBeVisible();
 
     // 新しいカテゴリを選択してTodoを作成
-    await page.getByText('テスト統合').click()
+    await page.getByText("テスト統合").click();
 
-    const todoInput = page.getByPlaceholder('新しいタスクを入力')
-    await todoInput.fill('統合テスト用Todo')
+    const todoInput = page.getByPlaceholder("新しいタスクを入力");
+    await todoInput.fill("統合テスト用Todo");
 
-    await page.getByRole('button', { name: '追加' }).click()
+    await page.getByRole("button", { name: "追加" }).click();
 
     // Todoが作成されることを確認
-    await expect(page.getByText('統合テスト用Todo')).toBeVisible()
-  })
-})
+    await expect(page.getByText("統合テスト用Todo")).toBeVisible();
+  });
+});

--- a/frontend/__tests__/e2e/layout-consistency.spec.ts
+++ b/frontend/__tests__/e2e/layout-consistency.spec.ts
@@ -1,58 +1,58 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from "@playwright/test";
 
-test.describe('Layout Consistency E2E Tests', () => {
+test.describe("Layout Consistency E2E Tests", () => {
   // 概要: ナビゲーション間でのレイアウト幅の一貫性をテスト
   // 目的: TodoページとCategoriesページ間でコンテンツ幅が一貫していることを保証
-  test('should maintain consistent layout width across navigation', async ({
+  test("should maintain consistent layout width across navigation", async ({
     page,
   }) => {
-    await page.goto('/')
-    await page.waitForSelector('.MuiContainer-root', { timeout: 10000 })
+    await page.goto("/");
+    await page.waitForSelector(".MuiContainer-root", { timeout: 10000 });
 
     // TodoページのContainer要素の幅を取得
-    const todoContainer = page.locator('.MuiContainer-root').first()
-    const todoContainerBox = await todoContainer.boundingBox()
-    expect(todoContainerBox).not.toBeNull()
+    const todoContainer = page.locator(".MuiContainer-root").first();
+    const todoContainerBox = await todoContainer.boundingBox();
+    expect(todoContainerBox).not.toBeNull();
 
     // カテゴリ管理ページに移動
-    await page.click('[role="tab"]:has-text("カテゴリ管理")')
-    await page.waitForURL('/categories')
-    await page.waitForSelector('.MuiContainer-root', { timeout: 10000 })
+    await page.click('[role="tab"]:has-text("カテゴリ管理")');
+    await page.waitForURL("/categories");
+    await page.waitForSelector(".MuiContainer-root", { timeout: 10000 });
 
     // Categoriesページのコンテナ幅を確認
-    const categoriesContainer = page.locator('.MuiContainer-root').first()
-    const categoriesContainerBox = await categoriesContainer.boundingBox()
-    expect(categoriesContainerBox).not.toBeNull()
+    const categoriesContainer = page.locator(".MuiContainer-root").first();
+    const categoriesContainerBox = await categoriesContainer.boundingBox();
+    expect(categoriesContainerBox).not.toBeNull();
 
     // 幅が一致していることを確認
-    expect(categoriesContainerBox!.width).toBe(todoContainerBox!.width)
-  })
+    expect(categoriesContainerBox!.width).toBe(todoContainerBox!.width);
+  });
 
   // 概要: ナビゲーションバーの一貫性をテスト
   // 目的: Navigation barが全ページで統一されていることを保証
-  test('should maintain navigation bar consistency across pages', async ({
+  test("should maintain navigation bar consistency across pages", async ({
     page,
   }) => {
-    const pages = ['/', '/categories']
+    const pages = ["/", "/categories"];
 
-    const navBarWidths: number[] = []
+    const navBarWidths: number[] = [];
 
     for (const path of pages) {
-      await page.goto(path)
-      await page.waitForSelector('.MuiTabs-root', { timeout: 10000 })
+      await page.goto(path);
+      await page.waitForSelector(".MuiTabs-root", { timeout: 10000 });
 
       // Navigation barの幅を測定
-      const navBar = page.locator('.MuiTabs-root').first()
-      const navBox = await navBar.boundingBox()
-      expect(navBox).not.toBeNull()
+      const navBar = page.locator(".MuiTabs-root").first();
+      const navBox = await navBar.boundingBox();
+      expect(navBox).not.toBeNull();
 
-      navBarWidths.push(navBox!.width)
+      navBarWidths.push(navBox!.width);
     }
 
     // 全ページでナビゲーション幅がほぼ同じであることを確認（1px程度の差は許容）
-    const firstWidth = navBarWidths[0]
-    expect(navBarWidths.every(width => Math.abs(width - firstWidth) <= 1)).toBe(
-      true
-    )
-  })
-})
+    const firstWidth = navBarWidths[0];
+    expect(
+      navBarWidths.every((width) => Math.abs(width - firstWidth) <= 1),
+    ).toBe(true);
+  });
+});

--- a/frontend/__tests__/e2e/navigation-theme.spec.ts
+++ b/frontend/__tests__/e2e/navigation-theme.spec.ts
@@ -1,181 +1,181 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from "@playwright/test";
 
-test.describe('Navigation Theme E2E Tests', () => {
+test.describe("Navigation Theme E2E Tests", () => {
   // 概要: ライトモード時のナビゲーションタブ表示をテスト
   // 目的: 選択されたタブが白色で表示され、非選択タブも視認可能であることを保証
-  test('should display navigation tabs with proper contrast in light mode', async ({
+  test("should display navigation tabs with proper contrast in light mode", async ({
     page,
   }) => {
-    await page.goto('/')
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 })
+    await page.goto("/");
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
 
     // ライトモードであることを確認（ダークモードボタンが表示されている）
-    const darkModeButton = page.getByRole('button', {
-      name: 'Switch to dark mode',
-    })
-    await expect(darkModeButton).toBeVisible()
+    const darkModeButton = page.getByRole("button", {
+      name: "Switch to dark mode",
+    });
+    await expect(darkModeButton).toBeVisible();
 
     // 選択されたTodoタブが表示されていることを確認
-    const selectedTab = page.getByRole('tab', { name: 'Todo page' })
-    await expect(selectedTab).toHaveAttribute('aria-selected', 'true')
-    await expect(selectedTab).toBeVisible()
+    const selectedTab = page.getByRole("tab", { name: "Todo page" });
+    await expect(selectedTab).toHaveAttribute("aria-selected", "true");
+    await expect(selectedTab).toBeVisible();
 
     // 非選択のカテゴリ管理タブも表示されていることを確認
-    const nonSelectedTab = page.getByRole('tab', {
-      name: 'Categories management page',
-    })
-    await expect(nonSelectedTab).toHaveAttribute('aria-selected', 'false')
-    await expect(nonSelectedTab).toBeVisible()
+    const nonSelectedTab = page.getByRole("tab", {
+      name: "Categories management page",
+    });
+    await expect(nonSelectedTab).toHaveAttribute("aria-selected", "false");
+    await expect(nonSelectedTab).toBeVisible();
 
     // カテゴリ管理タブをクリックして選択状態を変更
-    await nonSelectedTab.click()
-    await page.waitForURL('/categories')
+    await nonSelectedTab.click();
+    await page.waitForURL("/categories");
 
     // 新しく選択されたタブの状態確認
-    await expect(nonSelectedTab).toHaveAttribute('aria-selected', 'true')
-    await expect(selectedTab).toHaveAttribute('aria-selected', 'false')
-  })
+    await expect(nonSelectedTab).toHaveAttribute("aria-selected", "true");
+    await expect(selectedTab).toHaveAttribute("aria-selected", "false");
+  });
 
   // 概要: ダークモード切り替え機能をテスト
   // 目的: ダークモード切り替えボタンが正常に動作し、UI状態が適切に変化することを保証
-  test('should toggle dark mode correctly', async ({ page }) => {
-    await page.goto('/')
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 })
+  test("should toggle dark mode correctly", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
 
     // 初期状態（ライトモード）を確認
-    const toggleButton = page.getByRole('button', {
-      name: 'Switch to dark mode',
-    })
-    await expect(toggleButton).toBeVisible()
+    const toggleButton = page.getByRole("button", {
+      name: "Switch to dark mode",
+    });
+    await expect(toggleButton).toBeVisible();
 
     // body要素の背景色を取得（ライトモード）
     const lightModeBodyStyle = await page.evaluate(() => {
-      return window.getComputedStyle(document.body).backgroundColor
-    })
+      return window.getComputedStyle(document.body).backgroundColor;
+    });
 
     // ダークモードに切り替え
-    await toggleButton.click()
+    await toggleButton.click();
 
     // ボタンのテキストが変更されることを確認
-    const lightModeButton = page.getByRole('button', {
-      name: 'Switch to light mode',
-    })
-    await expect(lightModeButton).toBeVisible()
+    const lightModeButton = page.getByRole("button", {
+      name: "Switch to light mode",
+    });
+    await expect(lightModeButton).toBeVisible();
 
     // 背景色が変化したことを確認
     const darkModeBodyStyle = await page.evaluate(() => {
-      return window.getComputedStyle(document.body).backgroundColor
-    })
+      return window.getComputedStyle(document.body).backgroundColor;
+    });
 
-    expect(darkModeBodyStyle).not.toBe(lightModeBodyStyle)
+    expect(darkModeBodyStyle).not.toBe(lightModeBodyStyle);
 
     // ライトモードに戻す
-    await lightModeButton.click()
+    await lightModeButton.click();
 
     // 元の状態に戻ることを確認
-    await expect(toggleButton).toBeVisible()
-  })
+    await expect(toggleButton).toBeVisible();
+  });
 
   // 概要: ダークモード時のナビゲーションタブ表示をテスト
   // 目的: ダークモードでも適切なコントラストでタブが表示されることを保証
-  test('should display navigation tabs with proper contrast in dark mode', async ({
+  test("should display navigation tabs with proper contrast in dark mode", async ({
     page,
   }) => {
-    await page.goto('/')
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 })
+    await page.goto("/");
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
 
     // ダークモードに切り替え
-    const darkModeButton = page.getByRole('button', {
-      name: 'Switch to dark mode',
-    })
-    await darkModeButton.click()
+    const darkModeButton = page.getByRole("button", {
+      name: "Switch to dark mode",
+    });
+    await darkModeButton.click();
 
     // ダークモードになったことを確認
-    const lightModeButton = page.getByRole('button', {
-      name: 'Switch to light mode',
-    })
-    await expect(lightModeButton).toBeVisible()
+    const lightModeButton = page.getByRole("button", {
+      name: "Switch to light mode",
+    });
+    await expect(lightModeButton).toBeVisible();
 
     // 選択されたタブが表示されていることを確認
-    const selectedTab = page.getByRole('tab', { name: 'Todo page' })
-    await expect(selectedTab).toHaveAttribute('aria-selected', 'true')
-    await expect(selectedTab).toBeVisible()
+    const selectedTab = page.getByRole("tab", { name: "Todo page" });
+    await expect(selectedTab).toHaveAttribute("aria-selected", "true");
+    await expect(selectedTab).toBeVisible();
 
     // 非選択タブも表示されていることを確認
-    const nonSelectedTab = page.getByRole('tab', {
-      name: 'Categories management page',
-    })
-    await expect(nonSelectedTab).toHaveAttribute('aria-selected', 'false')
-    await expect(nonSelectedTab).toBeVisible()
+    const nonSelectedTab = page.getByRole("tab", {
+      name: "Categories management page",
+    });
+    await expect(nonSelectedTab).toHaveAttribute("aria-selected", "false");
+    await expect(nonSelectedTab).toBeVisible();
 
     // タブ切り替えもダークモードで正常に動作することを確認
-    await nonSelectedTab.click()
-    await page.waitForURL('/categories')
+    await nonSelectedTab.click();
+    await page.waitForURL("/categories");
 
-    await expect(nonSelectedTab).toHaveAttribute('aria-selected', 'true')
-    await expect(selectedTab).toHaveAttribute('aria-selected', 'false')
-  })
+    await expect(nonSelectedTab).toHaveAttribute("aria-selected", "true");
+    await expect(selectedTab).toHaveAttribute("aria-selected", "false");
+  });
 
   // 概要: ページ遷移時のダークモード状態維持をテスト
   // 目的: ページ間移動時にダークモード設定が保持されることを保証
-  test('should persist dark mode setting across page navigation', async ({
+  test("should persist dark mode setting across page navigation", async ({
     page,
   }) => {
-    await page.goto('/')
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 })
+    await page.goto("/");
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
 
     // ダークモードに切り替え
-    const darkModeButton = page.getByRole('button', {
-      name: 'Switch to dark mode',
-    })
-    await darkModeButton.click()
+    const darkModeButton = page.getByRole("button", {
+      name: "Switch to dark mode",
+    });
+    await darkModeButton.click();
 
     // ダークモードボタンが変更されることを確認
-    const lightModeButton = page.getByRole('button', {
-      name: 'Switch to light mode',
-    })
-    await expect(lightModeButton).toBeVisible()
+    const lightModeButton = page.getByRole("button", {
+      name: "Switch to light mode",
+    });
+    await expect(lightModeButton).toBeVisible();
 
     // カテゴリ管理ページに移動
-    const categoriesTab = page.getByRole('tab', {
-      name: 'Categories management page',
-    })
-    await categoriesTab.click()
-    await page.waitForURL('/categories')
+    const categoriesTab = page.getByRole("tab", {
+      name: "Categories management page",
+    });
+    await categoriesTab.click();
+    await page.waitForURL("/categories");
 
     // ダークモード状態が維持されていることを確認
-    await expect(lightModeButton).toBeVisible()
+    await expect(lightModeButton).toBeVisible();
 
     // Todoページに戻る
-    const todoTab = page.getByRole('tab', { name: 'Todo page' })
-    await todoTab.click()
-    await page.waitForURL('/')
+    const todoTab = page.getByRole("tab", { name: "Todo page" });
+    await todoTab.click();
+    await page.waitForURL("/");
 
     // まだダークモード状態であることを確認
-    await expect(lightModeButton).toBeVisible()
-  })
+    await expect(lightModeButton).toBeVisible();
+  });
 
   // 概要: ダークモード切り替えボタンのアクセシビリティをテスト
   // 目的: ダークモード切り替えボタンが適切なaria-labelを持つことを保証
-  test('should have proper accessibility labels for dark mode toggle', async ({
+  test("should have proper accessibility labels for dark mode toggle", async ({
     page,
   }) => {
-    await page.goto('/')
-    await page.waitForSelector('[role="tab"]', { timeout: 10000 })
+    await page.goto("/");
+    await page.waitForSelector('[role="tab"]', { timeout: 10000 });
 
     // ライトモード時のaria-label確認
-    const darkModeButton = page.getByRole('button', {
-      name: 'Switch to dark mode',
-    })
-    await expect(darkModeButton).toBeVisible()
+    const darkModeButton = page.getByRole("button", {
+      name: "Switch to dark mode",
+    });
+    await expect(darkModeButton).toBeVisible();
 
     // ダークモードに切り替え
-    await darkModeButton.click()
+    await darkModeButton.click();
 
     // ダークモード時のaria-label確認
-    const lightModeButton = page.getByRole('button', {
-      name: 'Switch to light mode',
-    })
-    await expect(lightModeButton).toBeVisible()
-  })
-})
+    const lightModeButton = page.getByRole("button", {
+      name: "Switch to light mode",
+    });
+    await expect(lightModeButton).toBeVisible();
+  });
+});

--- a/frontend/__tests__/e2e/todo-app.spec.ts
+++ b/frontend/__tests__/e2e/todo-app.spec.ts
@@ -1,614 +1,620 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from "@playwright/test";
 
-test.describe('Todo App E2E Tests', () => {
+test.describe("Todo App E2E Tests", () => {
   // 概要: ページが正しく読み込まれ、基本的なUI要素が表示されることを確認
   // 目的: アプリケーションの基本構造がブラウザで正しく動作することを保証
-  test('should load the todo app with basic elements', async ({ page }) => {
-    await page.goto('/')
+  test("should load the todo app with basic elements", async ({ page }) => {
+    await page.goto("/");
 
-    await expect(page.getByRole('heading', { name: /todo app/i })).toBeVisible()
-    await expect(page.getByPlaceholder('新しいタスクを入力')).toBeVisible()
-    await expect(page.getByRole('button', { name: '追加' })).toBeVisible()
-  })
+    await expect(
+      page.getByRole("heading", { name: /todo app/i }),
+    ).toBeVisible();
+    await expect(page.getByPlaceholder("新しいタスクを入力")).toBeVisible();
+    await expect(page.getByRole("button", { name: "追加" })).toBeVisible();
+  });
 
   // 概要: ユーザーが新しいTodoを追加できることをE2Eで確認
   // 目的: Todo追加機能がブラウザ環境で正しく動作することを保証
-  test('should add a new todo', async ({ page }) => {
-    await page.goto('/')
+  test("should add a new todo", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
-    await input.fill('Learn Playwright')
-    await addButton.click()
+    await input.fill("Learn Playwright");
+    await addButton.click();
 
-    await expect(page.getByText('Learn Playwright')).toBeVisible()
-    await expect(input).toHaveValue('')
-  })
+    await expect(page.getByText("Learn Playwright")).toBeVisible();
+    await expect(input).toHaveValue("");
+  });
 
   // 概要: ユーザーがTodoの完了状態を切り替えられることをE2Eで確認
   // 目的: Todo完了機能がブラウザ環境で正しく動作することを保証
-  test('should toggle todo completion', async ({ page }) => {
-    await page.goto('/')
+  test("should toggle todo completion", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
-    await input.fill('Test Todo')
-    await addButton.click()
+    await input.fill("Test Todo");
+    await addButton.click();
 
     // Todo項目のcheckboxを特定（FilterBarのSwitchと区別）
-    const checkbox = page.getByRole('checkbox').last()
-    await expect(checkbox).not.toBeChecked()
+    const checkbox = page.getByRole("checkbox").last();
+    await expect(checkbox).not.toBeChecked();
 
-    await checkbox.click()
-    await expect(checkbox).toBeChecked()
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
 
     // 完了済みTodoのテキストに取り消し線が適用されることを確認
-    const todoText = page.getByText('Test Todo')
-    await expect(todoText).toHaveCSS('text-decoration', /line-through/)
-  })
+    const todoText = page.getByText("Test Todo");
+    await expect(todoText).toHaveCSS("text-decoration", /line-through/);
+  });
 
   // 概要: ユーザーがTodoを削除できることをE2Eで確認
   // 目的: Todo削除機能がブラウザ環境で正しく動作することを保証
-  test('should delete a todo', async ({ page }) => {
-    await page.goto('/')
+  test("should delete a todo", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
-    await input.fill('Todo to delete')
-    await addButton.click()
+    await input.fill("Todo to delete");
+    await addButton.click();
 
-    await expect(page.getByText('Todo to delete')).toBeVisible()
+    await expect(page.getByText("Todo to delete")).toBeVisible();
 
-    const deleteButton = page.getByRole('button', {
-      name: 'delete',
+    const deleteButton = page.getByRole("button", {
+      name: "delete",
       exact: true,
-    })
-    await deleteButton.click()
+    });
+    await deleteButton.click();
 
-    await expect(page.getByText('Todo to delete')).not.toBeVisible()
-  })
+    await expect(page.getByText("Todo to delete")).not.toBeVisible();
+  });
 
   // 概要: 複数のTodoを管理できることをE2Eで確認
   // 目的: アプリケーションが複数のTodoを正しく表示・管理できることを保証
-  test('should handle multiple todos', async ({ page }) => {
-    await page.goto('/')
+  test("should handle multiple todos", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // 複数のTodoを追加
-    await input.fill('First Todo')
-    await addButton.click()
+    await input.fill("First Todo");
+    await addButton.click();
 
-    await input.fill('Second Todo')
-    await addButton.click()
+    await input.fill("Second Todo");
+    await addButton.click();
 
-    await input.fill('Third Todo')
-    await addButton.click()
+    await input.fill("Third Todo");
+    await addButton.click();
 
     // 全てのTodoが表示されることを確認
-    await expect(page.getByText('First Todo')).toBeVisible()
-    await expect(page.getByText('Second Todo')).toBeVisible()
-    await expect(page.getByText('Third Todo')).toBeVisible()
+    await expect(page.getByText("First Todo")).toBeVisible();
+    await expect(page.getByText("Second Todo")).toBeVisible();
+    await expect(page.getByText("Third Todo")).toBeVisible();
 
     // Todo項目のチェックボックスが3つ表示されることを確認（FilterBarのSwitchを除く）
-    const todoCheckboxes = page.locator('[data-indeterminate="false"]')
-    await expect(todoCheckboxes).toHaveCount(3)
-  })
+    const todoCheckboxes = page.locator('[data-indeterminate="false"]');
+    await expect(todoCheckboxes).toHaveCount(3);
+  });
 
   // 概要: 空のTodoが追加されないことをE2Eで確認
   // 目的: バリデーション機能がブラウザ環境で正しく動作することを保証
-  test('should not add empty todo', async ({ page }) => {
-    await page.goto('/')
+  test("should not add empty todo", async ({ page }) => {
+    await page.goto("/");
 
-    const addButton = page.getByRole('button', { name: '追加' })
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // 空の状態でAddボタンをクリック
-    await addButton.click()
+    await addButton.click();
 
     // Todo項目のチェックボックスが表示されないことを確認（FilterBarのSwitchは除く）
-    const todoCheckboxes = page.locator('[data-indeterminate="false"]')
-    await expect(todoCheckboxes).toHaveCount(0)
-  })
+    const todoCheckboxes = page.locator('[data-indeterminate="false"]');
+    await expect(todoCheckboxes).toHaveCount(0);
+  });
 
   // 概要: カテゴリ付きTodoを追加できることをE2Eで確認
   // 目的: カテゴリ機能がブラウザ環境で正しく動作することを保証
-  test('should add todo with category', async ({ page }) => {
-    await page.goto('/')
+  test("should add todo with category", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const categorySelect = page.getByLabel('カテゴリ').first()
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const categorySelect = page.getByLabel("カテゴリ").first();
+    const addButton = page.getByRole("button", { name: "追加" });
 
-    await input.fill('仕事のタスク')
-    await categorySelect.click()
-    await page.getByText('仕事').click()
-    await addButton.click()
+    await input.fill("仕事のタスク");
+    await categorySelect.click();
+    await page.getByText("仕事").click();
+    await addButton.click();
 
-    await expect(page.getByText('仕事のタスク')).toBeVisible()
+    await expect(page.getByText("仕事のタスク")).toBeVisible();
     // カテゴリ付きTodoが作成されたことを確認（表示確認は単体テストで実施済み）
-  })
+  });
 
   // 概要: タグ付きTodoを追加できることをE2Eで確認
   // 目的: タグ機能がブラウザ環境で正しく動作することを保証
-  test('should add todo with tags', async ({ page }) => {
-    await page.goto('/')
+  test("should add todo with tags", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const tagInput = page.getByLabel('タグ').first()
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const tagInput = page.getByLabel("タグ").first();
+    const addButton = page.getByRole("button", { name: "追加" });
 
-    await input.fill('タグ付きタスク')
-    await tagInput.fill('重要, 急ぎ')
-    await addButton.click()
+    await input.fill("タグ付きタスク");
+    await tagInput.fill("重要, 急ぎ");
+    await addButton.click();
 
-    await expect(page.getByText('タグ付きタスク')).toBeVisible()
+    await expect(page.getByText("タグ付きタスク")).toBeVisible();
     // タグ付きTodoが作成されたことを確認（タグ表示確認は単体テストで実施済み）
-  })
+  });
 
   // 概要: カテゴリとタグの両方を持つTodoを追加できることをE2Eで確認
   // 目的: カテゴリ・タグ機能の組み合わせがブラウザ環境で正しく動作することを保証
-  test('should add todo with both category and tags', async ({ page }) => {
-    await page.goto('/')
+  test("should add todo with both category and tags", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const categorySelect = page.getByLabel('カテゴリ').first()
-    const tagInput = page.getByLabel('タグ').first()
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const categorySelect = page.getByLabel("カテゴリ").first();
+    const tagInput = page.getByLabel("タグ").first();
+    const addButton = page.getByRole("button", { name: "追加" });
 
-    await input.fill('完全なタスク')
-    await categorySelect.click()
-    await page.getByText('プライベート').click()
-    await tagInput.fill('買い物, 今日中')
-    await addButton.click()
+    await input.fill("完全なタスク");
+    await categorySelect.click();
+    await page.getByText("プライベート").click();
+    await tagInput.fill("買い物, 今日中");
+    await addButton.click();
 
-    await expect(page.getByText('完全なタスク')).toBeVisible()
+    await expect(page.getByText("完全なタスク")).toBeVisible();
     // カテゴリとタグ両方を持つTodoが作成されたことを確認（表示確認は単体テストで実施済み）
-  })
+  });
 
   // 概要: フィルターバーが表示され、基本的なフィルター機能が動作することをE2Eで確認
   // 目的: フィルター機能の主要な動作がブラウザ環境で正しく機能することを保証
-  test('should filter todos by completion status', async ({ page }) => {
-    await page.goto('/')
+  test("should filter todos by completion status", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // 2つのTodoを追加
-    await input.fill('未完了タスク')
-    await addButton.click()
-    await input.fill('完了予定タスク')
-    await addButton.click()
+    await input.fill("未完了タスク");
+    await addButton.click();
+    await input.fill("完了予定タスク");
+    await addButton.click();
 
     // 1つ目のTodoを完了にする（FilterBarのSwitchを除く）
-    const todoCheckbox = page.locator('[data-indeterminate="false"]').first()
-    await todoCheckbox.click()
+    const todoCheckbox = page.locator('[data-indeterminate="false"]').first();
+    await todoCheckbox.click();
 
     // フィルターバーが表示されることを確認
-    await expect(page.getByText('フィルター')).toBeVisible()
+    await expect(page.getByText("フィルター")).toBeVisible();
 
     // 完了済みフィルターを選択
-    await page.getByLabel('完了済み').click()
+    await page.getByLabel("完了済み").click();
 
     // 完了済みTodoのみが表示されることを確認（1つ目が完了済み）
-    await expect(page.getByText('未完了タスク')).toBeVisible()
-    await expect(page.getByText('完了予定タスク')).not.toBeVisible()
+    await expect(page.getByText("未完了タスク")).toBeVisible();
+    await expect(page.getByText("完了予定タスク")).not.toBeVisible();
 
     // 未完了フィルターを選択
-    await page.getByLabel('未完了').click()
+    await page.getByLabel("未完了").click();
 
     // 未完了Todoのみが表示されることを確認（2つ目が未完了）
-    await expect(page.getByText('未完了タスク')).not.toBeVisible()
-    await expect(page.getByText('完了予定タスク')).toBeVisible()
-  })
+    await expect(page.getByText("未完了タスク")).not.toBeVisible();
+    await expect(page.getByText("完了予定タスク")).toBeVisible();
+  });
 
   // 概要: 検索フィルターが正しく動作することをE2Eで確認
   // 目的: テキスト検索フィルター機能がブラウザ環境で正しく動作することを保証
-  test('should filter todos by search text', async ({ page }) => {
-    await page.goto('/')
+  test("should filter todos by search text", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // 複数のTodoを追加
-    await input.fill('React学習')
-    await addButton.click()
-    await input.fill('Vue習得')
-    await addButton.click()
-    await input.fill('JavaScript復習')
-    await addButton.click()
+    await input.fill("React学習");
+    await addButton.click();
+    await input.fill("Vue習得");
+    await addButton.click();
+    await input.fill("JavaScript復習");
+    await addButton.click();
 
     // 検索フィルターを使用
-    const searchInput = page.getByLabel('検索')
-    await searchInput.fill('React')
+    const searchInput = page.getByLabel("検索");
+    await searchInput.fill("React");
 
     // Reactを含むTodoのみが表示されることを確認
-    await expect(page.getByText('React学習')).toBeVisible()
-    await expect(page.getByText('Vue習得')).not.toBeVisible()
-    await expect(page.getByText('JavaScript復習')).not.toBeVisible()
+    await expect(page.getByText("React学習")).toBeVisible();
+    await expect(page.getByText("Vue習得")).not.toBeVisible();
+    await expect(page.getByText("JavaScript復習")).not.toBeVisible();
 
     // 検索をクリア
-    await searchInput.clear()
-    await searchInput.fill('学習')
+    await searchInput.clear();
+    await searchInput.fill("学習");
 
     // 学習を含むTodoが表示されることを確認
-    await expect(page.getByText('React学習')).toBeVisible()
-    await expect(page.getByText('Vue習得')).not.toBeVisible()
-    await expect(page.getByText('JavaScript復習')).not.toBeVisible()
-  })
+    await expect(page.getByText("React学習")).toBeVisible();
+    await expect(page.getByText("Vue習得")).not.toBeVisible();
+    await expect(page.getByText("JavaScript復習")).not.toBeVisible();
+  });
 
   // 概要: フィルターリセット機能が正しく動作することをE2Eで確認
   // 目的: フィルター状態をリセットする機能がブラウザ環境で正しく動作することを保証
-  test('should reset filters when reset button is clicked', async ({
+  test("should reset filters when reset button is clicked", async ({
     page,
   }) => {
-    await page.goto('/')
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // Todoを追加
-    await input.fill('テストタスク')
-    await addButton.click()
+    await input.fill("テストタスク");
+    await addButton.click();
 
     // 検索フィルターを適用
-    const searchInput = page.getByLabel('検索')
-    await searchInput.fill('存在しない')
+    const searchInput = page.getByLabel("検索");
+    await searchInput.fill("存在しない");
 
     // Todoが表示されないことを確認
-    await expect(page.getByText('テストタスク')).not.toBeVisible()
+    await expect(page.getByText("テストタスク")).not.toBeVisible();
 
     // リセットボタンをクリック
-    await page.getByText('リセット').click()
+    await page.getByText("リセット").click();
 
     // 検索フィールドがクリアされ、Todoが再表示されることを確認
-    await expect(searchInput).toHaveValue('')
-    await expect(page.getByText('テストタスク')).toBeVisible()
-  })
+    await expect(searchInput).toHaveValue("");
+    await expect(page.getByText("テストタスク")).toBeVisible();
+  });
 
   // 概要: ドラッグハンドルがホバー時に表示されることをテスト
   // 目的: ユーザーがドラッグ&ドロップ機能を発見できるUIになっていることを保証
-  test('should show drag handle on hover', async ({ page }) => {
-    await page.goto('/')
+  test("should show drag handle on hover", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // テスト用のTodoを追加
-    await input.fill('Draggable Todo')
-    await addButton.click()
+    await input.fill("Draggable Todo");
+    await addButton.click();
 
     // TodoItemがレンダリングされるまで待機
-    await expect(page.getByText('Draggable Todo')).toBeVisible()
+    await expect(page.getByText("Draggable Todo")).toBeVisible();
 
     // ドラッグハンドルが存在することを確認
     const dragHandle = page
-      .getByRole('button', { name: 'Drag to reorder' })
-      .last()
-    await expect(dragHandle).toBeVisible()
-  })
+      .getByRole("button", { name: "Drag to reorder" })
+      .last();
+    await expect(dragHandle).toBeVisible();
+  });
 
   // 概要: ドラッグ&ドロップUI統合後の基本機能動作をテスト
   // 目的: SortableTodoItemでラップした後もTodoItemの基本機能（完了状態切り替え）が正常に動作することを保証
-  test('should maintain todo functionality with drag and drop UI', async ({
+  test("should maintain todo functionality with drag and drop UI", async ({
     page,
   }) => {
-    await page.goto('/')
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // テスト用のTodoを追加
-    await input.fill('Test Todo with DnD')
-    await addButton.click()
+    await input.fill("Test Todo with DnD");
+    await addButton.click();
 
     // TodoItemがレンダリングされるまで待機
-    await expect(page.getByText('Test Todo with DnD')).toBeVisible()
+    await expect(page.getByText("Test Todo with DnD")).toBeVisible();
 
     // ドラッグハンドルが存在することを確認
     const dragHandle = page
-      .getByRole('button', { name: 'Drag to reorder' })
-      .last()
-    await expect(dragHandle).toBeVisible()
+      .getByRole("button", { name: "Drag to reorder" })
+      .last();
+    await expect(dragHandle).toBeVisible();
 
     // TodoItemの基本機能（チェックボックス）が動作することを確認
-    const todoButton = page.getByRole('button', { name: 'Test Todo with DnD' })
-    const checkbox = todoButton.locator('input[type="checkbox"]')
-    await checkbox.click()
-    await expect(checkbox).toBeChecked()
-  })
+    const todoButton = page.getByRole("button", { name: "Test Todo with DnD" });
+    const checkbox = todoButton.locator('input[type="checkbox"]');
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+  });
 
   // 概要: 編集ボタンをクリックしてTodo編集モードに入ることをE2Eで確認
   // 目的: 編集ボタンによる編集機能がブラウザ環境で正しく動作することを保証
-  test('should edit todo using edit button', async ({ page }) => {
-    await page.goto('/')
+  test("should edit todo using edit button", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // テスト用のTodoを追加
-    await input.fill('Original Todo Text')
-    await addButton.click()
+    await input.fill("Original Todo Text");
+    await addButton.click();
 
-    await expect(page.getByText('Original Todo Text')).toBeVisible()
+    await expect(page.getByText("Original Todo Text")).toBeVisible();
 
     // 編集ボタンをクリック
-    const editButton = page.getByRole('button', { name: 'edit', exact: true })
-    await editButton.click()
+    const editButton = page.getByRole("button", { name: "edit", exact: true });
+    await editButton.click();
 
     // 編集モードに入ったことを確認（保存・キャンセルボタンが表示される）
-    await expect(page.getByRole('button', { name: '保存' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'キャンセル' })).toBeVisible()
+    await expect(page.getByRole("button", { name: "保存" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "キャンセル" }),
+    ).toBeVisible();
 
     // 編集フォームが完全に描画されるまで待機
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(500);
 
     // 編集フィールドを特定 - multilineのTextFieldを特定
-    const editInput = page.locator('textarea').first()
-    await expect(editInput).toBeVisible()
-    await expect(editInput).toHaveValue('Original Todo Text')
+    const editInput = page.locator("textarea").first();
+    await expect(editInput).toBeVisible();
+    await expect(editInput).toHaveValue("Original Todo Text");
 
     // テキストを変更
-    await editInput.fill('Updated Todo Text')
+    await editInput.fill("Updated Todo Text");
 
     // 保存ボタンをクリック
-    const saveButton = page.getByRole('button', { name: '保存' })
-    await saveButton.click()
+    const saveButton = page.getByRole("button", { name: "保存" });
+    await saveButton.click();
 
-    await page.waitForTimeout(1000)
+    await page.waitForTimeout(1000);
 
     // 更新されたテキストが表示されることを確認
-    await expect(page.getByText('Updated Todo Text')).toBeVisible()
-    await expect(page.getByText('Original Todo Text')).not.toBeVisible()
+    await expect(page.getByText("Updated Todo Text")).toBeVisible();
+    await expect(page.getByText("Original Todo Text")).not.toBeVisible();
 
     // 編集ボタンが再び表示されることを確認
     await expect(
-      page.getByRole('button', { name: 'edit', exact: true })
-    ).toBeVisible()
-  })
+      page.getByRole("button", { name: "edit", exact: true }),
+    ).toBeVisible();
+  });
 
   // 概要: ダブルクリックでTodo編集モードに入ることをE2Eで確認
   // 目的: ダブルクリック編集機能がブラウザ環境で正しく動作することを保証
-  test('should edit todo using double click', async ({ page }) => {
-    await page.goto('/')
+  test("should edit todo using double click", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // テスト用のTodoを追加
-    await input.fill('Double Click Todo')
-    await addButton.click()
+    await input.fill("Double Click Todo");
+    await addButton.click();
 
-    const todoText = page.getByText('Double Click Todo')
-    await expect(todoText).toBeVisible()
+    const todoText = page.getByText("Double Click Todo");
+    await expect(todoText).toBeVisible();
 
     // Todoテキストをダブルクリック
-    await todoText.dblclick()
+    await todoText.dblclick();
 
     // 編集モードに入ったことを確認
-    await expect(page.getByRole('button', { name: '保存' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'キャンセル' })).toBeVisible()
+    await expect(page.getByRole("button", { name: "保存" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "キャンセル" }),
+    ).toBeVisible();
 
     // 編集フィールドが表示されることを確認
-    const editInput = page.locator('textarea').first()
-    await expect(editInput).toBeVisible()
-    await expect(editInput).toHaveValue('Double Click Todo')
-  })
+    const editInput = page.locator("textarea").first();
+    await expect(editInput).toBeVisible();
+    await expect(editInput).toHaveValue("Double Click Todo");
+  });
 
   // 概要: Todo編集のキャンセル機能がE2Eで正しく動作することを確認
   // 目的: 編集キャンセル機能がブラウザ環境で正しく動作することを保証
-  test('should cancel todo editing', async ({ page }) => {
-    await page.goto('/')
+  test("should cancel todo editing", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // テスト用のTodoを追加
-    await input.fill('Cancel Edit Todo')
-    await addButton.click()
+    await input.fill("Cancel Edit Todo");
+    await addButton.click();
 
-    await expect(page.getByText('Cancel Edit Todo')).toBeVisible()
+    await expect(page.getByText("Cancel Edit Todo")).toBeVisible();
 
     // 編集ボタンをクリック
-    const editButton = page.getByRole('button', { name: 'edit', exact: true })
-    await editButton.click()
+    const editButton = page.getByRole("button", { name: "edit", exact: true });
+    await editButton.click();
 
     // テキストを変更
-    const editInput = page.locator('textarea').first()
-    await expect(editInput).toHaveValue('Cancel Edit Todo')
-    await editInput.fill('Modified Text')
+    const editInput = page.locator("textarea").first();
+    await expect(editInput).toHaveValue("Cancel Edit Todo");
+    await editInput.fill("Modified Text");
 
     // キャンセルボタンをクリック
-    const cancelButton = page.getByRole('button', { name: 'キャンセル' })
-    await cancelButton.click()
+    const cancelButton = page.getByRole("button", { name: "キャンセル" });
+    await cancelButton.click();
 
     // 元のテキストが表示されることを確認
-    await expect(page.getByText('Cancel Edit Todo')).toBeVisible()
-    await expect(page.getByText('Modified Text')).not.toBeVisible()
+    await expect(page.getByText("Cancel Edit Todo")).toBeVisible();
+    await expect(page.getByText("Modified Text")).not.toBeVisible();
 
     // 編集ボタンが再び表示されることを確認
     await expect(
-      page.getByRole('button', { name: 'edit', exact: true })
-    ).toBeVisible()
-  })
+      page.getByRole("button", { name: "edit", exact: true }),
+    ).toBeVisible();
+  });
 
   // 概要: Enterキーで編集を保存できることをE2Eで確認
   // 目的: キーボードショートカット（Enter）がブラウザ環境で正しく動作することを保証
-  test('should save todo edit with Enter key', async ({ page }) => {
-    await page.goto('/')
+  test("should save todo edit with Enter key", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // テスト用のTodoを追加
-    await input.fill('Enter Save Todo')
-    await addButton.click()
+    await input.fill("Enter Save Todo");
+    await addButton.click();
 
-    await expect(page.getByText('Enter Save Todo')).toBeVisible()
+    await expect(page.getByText("Enter Save Todo")).toBeVisible();
 
     // 編集ボタンをクリック
-    const editButton = page.getByRole('button', { name: 'edit', exact: true })
-    await editButton.click()
+    const editButton = page.getByRole("button", { name: "edit", exact: true });
+    await editButton.click();
 
     // テキストを変更してEnterキーを押す
-    const editInput = page.locator('textarea').first()
-    await expect(editInput).toHaveValue('Enter Save Todo')
-    await editInput.fill('Saved with Enter')
-    await editInput.press('Enter')
+    const editInput = page.locator("textarea").first();
+    await expect(editInput).toHaveValue("Enter Save Todo");
+    await editInput.fill("Saved with Enter");
+    await editInput.press("Enter");
 
     // 更新されたテキストが表示されることを確認
-    await expect(page.getByText('Saved with Enter')).toBeVisible()
-    await expect(page.getByText('Enter Save Todo')).not.toBeVisible()
-  })
+    await expect(page.getByText("Saved with Enter")).toBeVisible();
+    await expect(page.getByText("Enter Save Todo")).not.toBeVisible();
+  });
 
   // 概要: Escapeキーで編集をキャンセルできることをE2Eで確認
   // 目的: キーボードショートカット（Escape）がブラウザ環境で正しく動作することを保証
-  test('should cancel todo edit with Escape key', async ({ page }) => {
-    await page.goto('/')
+  test("should cancel todo edit with Escape key", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // テスト用のTodoを追加
-    await input.fill('Escape Cancel Todo')
-    await addButton.click()
+    await input.fill("Escape Cancel Todo");
+    await addButton.click();
 
-    await expect(page.getByText('Escape Cancel Todo')).toBeVisible()
+    await expect(page.getByText("Escape Cancel Todo")).toBeVisible();
 
     // 編集ボタンをクリック
-    const editButton = page.getByRole('button', { name: 'edit', exact: true })
-    await editButton.click()
+    const editButton = page.getByRole("button", { name: "edit", exact: true });
+    await editButton.click();
 
     // テキストを変更してEscapeキーを押す
-    const editInput = page.locator('textarea').first()
-    await expect(editInput).toHaveValue('Escape Cancel Todo')
-    await editInput.fill('Modified with Escape')
-    await editInput.press('Escape')
+    const editInput = page.locator("textarea").first();
+    await expect(editInput).toHaveValue("Escape Cancel Todo");
+    await editInput.fill("Modified with Escape");
+    await editInput.press("Escape");
 
     // 元のテキストが表示されることを確認
-    await expect(page.getByText('Escape Cancel Todo')).toBeVisible()
-    await expect(page.getByText('Modified with Escape')).not.toBeVisible()
-  })
+    await expect(page.getByText("Escape Cancel Todo")).toBeVisible();
+    await expect(page.getByText("Modified with Escape")).not.toBeVisible();
+  });
 
   // 概要: カテゴリを含むTodoの編集機能をE2Eで確認
   // 目的: カテゴリ編集機能がブラウザ環境で正しく動作することを保証
-  test('should edit todo with category', async ({ page }) => {
-    await page.goto('/')
+  test("should edit todo with category", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const categorySelect = page.getByLabel('カテゴリ').first()
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const categorySelect = page.getByLabel("カテゴリ").first();
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // カテゴリ付きTodoを追加
-    await input.fill('Category Todo')
-    await categorySelect.click()
-    await page.getByText('仕事').click()
-    await addButton.click()
+    await input.fill("Category Todo");
+    await categorySelect.click();
+    await page.getByText("仕事").click();
+    await addButton.click();
 
-    await expect(page.getByText('Category Todo')).toBeVisible()
+    await expect(page.getByText("Category Todo")).toBeVisible();
 
     // 編集ボタンをクリック
-    const editButton = page.getByRole('button', { name: 'edit', exact: true })
-    await editButton.click()
+    const editButton = page.getByRole("button", { name: "edit", exact: true });
+    await editButton.click();
 
     // カテゴリセレクトが編集フォームに表示されることを確認
-    const editCategorySelect = page.getByLabel('カテゴリ').last()
-    await expect(editCategorySelect).toBeVisible()
+    const editCategorySelect = page.getByLabel("カテゴリ").last();
+    await expect(editCategorySelect).toBeVisible();
 
     // カテゴリを変更
-    await editCategorySelect.click()
-    await page.getByText('プライベート').click()
+    await editCategorySelect.click();
+    await page.getByText("プライベート").click();
 
     // テキストも変更
-    const editInput = page.locator('textarea').first()
-    await expect(editInput).toHaveValue('Category Todo')
-    await editInput.fill('Updated Category Todo')
+    const editInput = page.locator("textarea").first();
+    await expect(editInput).toHaveValue("Category Todo");
+    await editInput.fill("Updated Category Todo");
 
     // 保存
-    const saveButton = page.getByRole('button', { name: '保存' })
-    await saveButton.click()
+    const saveButton = page.getByRole("button", { name: "保存" });
+    await saveButton.click();
 
     // 更新されたテキストが表示されることを確認
-    await expect(page.getByText('Updated Category Todo')).toBeVisible()
-  })
+    await expect(page.getByText("Updated Category Todo")).toBeVisible();
+  });
 
   // 概要: タグを含むTodoの編集機能をE2Eで確認
   // 目的: タグ編集機能がブラウザ環境で正しく動作することを保証
-  test('should edit todo with tags', async ({ page }) => {
-    await page.goto('/')
+  test("should edit todo with tags", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const tagInput = page.getByLabel('タグ').first()
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const tagInput = page.getByLabel("タグ").first();
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // タグ付きTodoを追加
-    await input.fill('Tagged Todo')
-    await tagInput.fill('初期タグ1, 初期タグ2')
-    await addButton.click()
+    await input.fill("Tagged Todo");
+    await tagInput.fill("初期タグ1, 初期タグ2");
+    await addButton.click();
 
-    await expect(page.getByText('Tagged Todo')).toBeVisible()
+    await expect(page.getByText("Tagged Todo")).toBeVisible();
 
     // 編集ボタンをクリック
-    const editButton = page.getByRole('button', { name: 'edit', exact: true })
-    await editButton.click()
+    const editButton = page.getByRole("button", { name: "edit", exact: true });
+    await editButton.click();
 
     // タグ入力フィールドが編集フォームに表示されることを確認
-    const editTagInput = page.getByLabel('タグ').last() // 編集フォーム内のタグ入力
-    await expect(editTagInput).toBeVisible()
-    await expect(editTagInput).toHaveValue('初期タグ1, 初期タグ2')
+    const editTagInput = page.getByLabel("タグ").last(); // 編集フォーム内のタグ入力
+    await expect(editTagInput).toBeVisible();
+    await expect(editTagInput).toHaveValue("初期タグ1, 初期タグ2");
 
     // タグを変更
-    await editTagInput.fill('更新タグ1, 更新タグ2, 新タグ')
+    await editTagInput.fill("更新タグ1, 更新タグ2, 新タグ");
 
     // テキストも変更
-    const editTextInput = page.locator('textarea').first() // テキスト用の入力フィールド（1番目）
-    await expect(editTextInput).toHaveValue('Tagged Todo')
-    await editTextInput.fill('Updated Tagged Todo')
+    const editTextInput = page.locator("textarea").first(); // テキスト用の入力フィールド（1番目）
+    await expect(editTextInput).toHaveValue("Tagged Todo");
+    await editTextInput.fill("Updated Tagged Todo");
 
     // 保存
-    const saveButton = page.getByRole('button', { name: '保存' })
-    await saveButton.click()
+    const saveButton = page.getByRole("button", { name: "保存" });
+    await saveButton.click();
 
     // 更新されたテキストが表示されることを確認
-    await expect(page.getByText('Updated Tagged Todo')).toBeVisible()
-  })
+    await expect(page.getByText("Updated Tagged Todo")).toBeVisible();
+  });
 
   // 概要: 編集中は削除ボタンが非表示になることをE2Eで確認
   // 目的: 編集中の誤削除防止機能がブラウザ環境で正しく動作することを保証
-  test('should hide delete button during edit', async ({ page }) => {
-    await page.goto('/')
+  test("should hide delete button during edit", async ({ page }) => {
+    await page.goto("/");
 
-    const input = page.getByPlaceholder('新しいタスクを入力')
-    const addButton = page.getByRole('button', { name: '追加' })
+    const input = page.getByPlaceholder("新しいタスクを入力");
+    const addButton = page.getByRole("button", { name: "追加" });
 
     // テスト用のTodoを追加
-    await input.fill('Delete Hidden Todo')
-    await addButton.click()
+    await input.fill("Delete Hidden Todo");
+    await addButton.click();
 
-    await expect(page.getByText('Delete Hidden Todo')).toBeVisible()
+    await expect(page.getByText("Delete Hidden Todo")).toBeVisible();
 
     // 削除ボタンが表示されることを確認
-    const deleteButton = page.getByRole('button', {
-      name: 'delete',
+    const deleteButton = page.getByRole("button", {
+      name: "delete",
       exact: true,
-    })
-    await expect(deleteButton).toBeVisible()
+    });
+    await expect(deleteButton).toBeVisible();
 
     // 編集ボタンをクリック
-    const editButton = page.getByRole('button', { name: 'edit', exact: true })
-    await editButton.click()
+    const editButton = page.getByRole("button", { name: "edit", exact: true });
+    await editButton.click();
 
     // 編集中は削除ボタンが非表示になることを確認
-    await expect(deleteButton).not.toBeVisible()
+    await expect(deleteButton).not.toBeVisible();
 
     // 編集をキャンセル
-    const cancelButton = page.getByRole('button', { name: 'キャンセル' })
-    await cancelButton.click()
+    const cancelButton = page.getByRole("button", { name: "キャンセル" });
+    await cancelButton.click();
 
     // 削除ボタンが再び表示されることを確認
-    await expect(deleteButton).toBeVisible()
-  })
-})
+    await expect(deleteButton).toBeVisible();
+  });
+});

--- a/frontend/__tests__/hooks/useCategories.test.ts
+++ b/frontend/__tests__/hooks/useCategories.test.ts
@@ -1,189 +1,191 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
-import { useCategories } from '../../src/hooks/useCategories'
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCategories } from "../../src/hooks/useCategories";
 
 // localStorageのモック
 const localStorageMock = (() => {
-  let store: Record<string, string> = {}
+  let store: Record<string, string> = {};
 
   return {
     getItem: (key: string) => store[key] || null,
     setItem: (key: string, value: string) => {
-      store[key] = value.toString()
+      store[key] = value.toString();
     },
     removeItem: (key: string) => {
-      delete store[key]
+      delete store[key];
     },
     clear: () => {
-      store = {}
+      store = {};
     },
-  }
-})()
+  };
+})();
 
-Object.defineProperty(window, 'localStorage', {
+Object.defineProperty(window, "localStorage", {
   value: localStorageMock,
-})
+});
 
-describe('useCategories', () => {
+describe("useCategories", () => {
   beforeEach(() => {
-    localStorage.clear()
-  })
+    localStorage.clear();
+  });
 
   // 概要: 初期状態でデフォルトカテゴリが存在することを確認
   // 目的: アプリ起動時に必要なカテゴリが自動的に利用可能であることを保証
-  it('初期状態でデフォルトカテゴリが存在する', () => {
-    const { result } = renderHook(() => useCategories())
+  it("初期状態でデフォルトカテゴリが存在する", () => {
+    const { result } = renderHook(() => useCategories());
 
-    expect(result.current.categories).toHaveLength(3)
-    expect(result.current.categories[0].name).toBe('仕事')
-    expect(result.current.categories[1].name).toBe('プライベート')
-    expect(result.current.categories[2].name).toBe('その他')
-  })
+    expect(result.current.categories).toHaveLength(3);
+    expect(result.current.categories[0].name).toBe("仕事");
+    expect(result.current.categories[1].name).toBe("プライベート");
+    expect(result.current.categories[2].name).toBe("その他");
+  });
 
   // 概要: 新しいカテゴリを追加する機能のテスト
   // 目的: addCategory関数が正しく動作し、カテゴリが増えることを確認
-  it('カテゴリを追加できる', () => {
-    const { result } = renderHook(() => useCategories())
+  it("カテゴリを追加できる", () => {
+    const { result } = renderHook(() => useCategories());
 
     act(() => {
-      result.current.addCategory('学習', '#4caf50')
-    })
+      result.current.addCategory("学習", "#4caf50");
+    });
 
-    expect(result.current.categories).toHaveLength(4)
-    expect(result.current.categories[3].name).toBe('学習')
-    expect(result.current.categories[3].color).toBe('#4caf50')
-  })
+    expect(result.current.categories).toHaveLength(4);
+    expect(result.current.categories[3].name).toBe("学習");
+    expect(result.current.categories[3].color).toBe("#4caf50");
+  });
 
   // 概要: 重複したカテゴリ名の追加を防ぐ機能のテスト
   // 目的: 同じ名前のカテゴリが重複して作成されないことを確認
-  it('同じ名前のカテゴリは追加できない', () => {
-    const { result } = renderHook(() => useCategories())
+  it("同じ名前のカテゴリは追加できない", () => {
+    const { result } = renderHook(() => useCategories());
 
     act(() => {
-      result.current.addCategory('仕事', '#ff5722')
-    })
+      result.current.addCategory("仕事", "#ff5722");
+    });
 
     // 仕事カテゴリは既に存在するため、追加されない
-    expect(result.current.categories).toHaveLength(3)
-  })
+    expect(result.current.categories).toHaveLength(3);
+  });
 
   // 概要: 既存カテゴリの名前と色を変更する機能のテスト
   // 目的: updateCategory関数が正しく動作することを確認
-  it('カテゴリを更新できる', () => {
-    const { result } = renderHook(() => useCategories())
+  it("カテゴリを更新できる", () => {
+    const { result } = renderHook(() => useCategories());
 
-    const categoryToUpdate = result.current.categories[0]
+    const categoryToUpdate = result.current.categories[0];
 
     act(() => {
       result.current.updateCategory(
         categoryToUpdate.id,
-        '重要な仕事',
-        '#f44336'
-      )
-    })
+        "重要な仕事",
+        "#f44336",
+      );
+    });
 
     const updatedCategory = result.current.categories.find(
-      c => c.id === categoryToUpdate.id
-    )
-    expect(updatedCategory?.name).toBe('重要な仕事')
-    expect(updatedCategory?.color).toBe('#f44336')
-  })
+      (c) => c.id === categoryToUpdate.id,
+    );
+    expect(updatedCategory?.name).toBe("重要な仕事");
+    expect(updatedCategory?.color).toBe("#f44336");
+  });
 
   // 概要: 存在しないカテゴリIDでの更新処理のテスト
   // 目的: 不正なIDでの更新が安全に無視されることを確認
-  it('存在しないカテゴリの更新は無視される', () => {
-    const { result } = renderHook(() => useCategories())
-    const originalCategories = [...result.current.categories]
+  it("存在しないカテゴリの更新は無視される", () => {
+    const { result } = renderHook(() => useCategories());
+    const originalCategories = [...result.current.categories];
 
     act(() => {
-      result.current.updateCategory('non-existent-id', '存在しない', '#000000')
-    })
+      result.current.updateCategory("non-existent-id", "存在しない", "#000000");
+    });
 
-    expect(result.current.categories).toEqual(originalCategories)
-  })
+    expect(result.current.categories).toEqual(originalCategories);
+  });
 
   // 概要: カテゴリ削除機能のテスト
   // 目的: deleteCategory関数が正しく動作し、カテゴリが削除されることを確認
-  it('カテゴリを削除できる', () => {
-    const { result } = renderHook(() => useCategories())
+  it("カテゴリを削除できる", () => {
+    const { result } = renderHook(() => useCategories());
 
-    const categoryToDelete = result.current.categories[0]
+    const categoryToDelete = result.current.categories[0];
 
     act(() => {
-      result.current.deleteCategory(categoryToDelete.id)
-    })
+      result.current.deleteCategory(categoryToDelete.id);
+    });
 
-    expect(result.current.categories).toHaveLength(2)
+    expect(result.current.categories).toHaveLength(2);
     expect(
-      result.current.categories.find(c => c.id === categoryToDelete.id)
-    ).toBeUndefined()
-  })
+      result.current.categories.find((c) => c.id === categoryToDelete.id),
+    ).toBeUndefined();
+  });
 
   // 概要: 存在しないカテゴリIDでの削除処理のテスト
   // 目的: 不正なIDでの削除が安全に無視されることを確認
-  it('存在しないカテゴリの削除は無視される', () => {
-    const { result } = renderHook(() => useCategories())
-    const originalLength = result.current.categories.length
+  it("存在しないカテゴリの削除は無視される", () => {
+    const { result } = renderHook(() => useCategories());
+    const originalLength = result.current.categories.length;
 
     act(() => {
-      result.current.deleteCategory('non-existent-id')
-    })
+      result.current.deleteCategory("non-existent-id");
+    });
 
-    expect(result.current.categories).toHaveLength(originalLength)
-  })
+    expect(result.current.categories).toHaveLength(originalLength);
+  });
 
   // 概要: IDによるカテゴリ検索機能のテスト
   // 目的: getCategoryById関数が正しいカテゴリを返すことを確認
-  it('IDでカテゴリを取得できる', () => {
-    const { result } = renderHook(() => useCategories())
+  it("IDでカテゴリを取得できる", () => {
+    const { result } = renderHook(() => useCategories());
 
-    const firstCategory = result.current.categories[0]
-    const foundCategory = result.current.getCategoryById(firstCategory.id)
+    const firstCategory = result.current.categories[0];
+    const foundCategory = result.current.getCategoryById(firstCategory.id);
 
-    expect(foundCategory).toEqual(firstCategory)
-  })
+    expect(foundCategory).toEqual(firstCategory);
+  });
 
   // 概要: 存在しないIDでの検索処理のテスト
   // 目的: 不正なIDでundefinedが返されることを確認
-  it('存在しないIDの場合はundefinedを返す', () => {
-    const { result } = renderHook(() => useCategories())
+  it("存在しないIDの場合はundefinedを返す", () => {
+    const { result } = renderHook(() => useCategories());
 
-    const foundCategory = result.current.getCategoryById('non-existent-id')
+    const foundCategory = result.current.getCategoryById("non-existent-id");
 
-    expect(foundCategory).toBeUndefined()
-  })
+    expect(foundCategory).toBeUndefined();
+  });
 
   // 概要: カテゴリデータの永続化機能のテスト
   // 目的: 追加したカテゴリがlocalStorageに保存され復元されることを確認
-  it('カテゴリがlocalStorageに永続化される', () => {
-    const { result } = renderHook(() => useCategories())
+  it("カテゴリがlocalStorageに永続化される", () => {
+    const { result } = renderHook(() => useCategories());
 
     act(() => {
-      result.current.addCategory('テストカテゴリ', '#123456')
-    })
+      result.current.addCategory("テストカテゴリ", "#123456");
+    });
 
     // 新しいフックインスタンスを作成して、永続化されているかを確認
-    const { result: newResult } = renderHook(() => useCategories())
+    const { result: newResult } = renderHook(() => useCategories());
 
-    expect(newResult.current.categories).toHaveLength(4)
-    expect(newResult.current.categories[3].name).toBe('テストカテゴリ')
-  })
+    expect(newResult.current.categories).toHaveLength(4);
+    expect(newResult.current.categories[3].name).toBe("テストカテゴリ");
+  });
 
   // 概要: デフォルトカテゴリの色設定のテスト
   // 目的: 各デフォルトカテゴリが期待される色を持つことを確認
-  it('デフォルトカテゴリが正しい色を持つ', () => {
-    const { result } = renderHook(() => useCategories())
+  it("デフォルトカテゴリが正しい色を持つ", () => {
+    const { result } = renderHook(() => useCategories());
 
-    const workCategory = result.current.categories.find(c => c.name === '仕事')
+    const workCategory = result.current.categories.find(
+      (c) => c.name === "仕事",
+    );
     const privateCategory = result.current.categories.find(
-      c => c.name === 'プライベート'
-    )
+      (c) => c.name === "プライベート",
+    );
     const otherCategory = result.current.categories.find(
-      c => c.name === 'その他'
-    )
+      (c) => c.name === "その他",
+    );
 
-    expect(workCategory?.color).toBe('#1976d2')
-    expect(privateCategory?.color).toBe('#ff5722')
-    expect(otherCategory?.color).toBe('#9e9e9e')
-  })
-})
+    expect(workCategory?.color).toBe("#1976d2");
+    expect(privateCategory?.color).toBe("#ff5722");
+    expect(otherCategory?.color).toBe("#9e9e9e");
+  });
+});

--- a/frontend/__tests__/hooks/useCategoryManagement.test.ts
+++ b/frontend/__tests__/hooks/useCategoryManagement.test.ts
@@ -1,148 +1,148 @@
-import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { useCategoryManagement } from '../../src/hooks/useCategoryManagement'
-import type { CategoryFormData } from '../../src/types/category'
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useCategoryManagement } from "../../src/hooks/useCategoryManagement";
+import type { CategoryFormData } from "../../src/types/category";
 
 // useLocalStorageをモック
-vi.mock('../../src/hooks/useLocalStorage', () => ({
+vi.mock("../../src/hooks/useLocalStorage", () => ({
   useLocalStorage: vi.fn(),
-}))
+}));
 
-describe('useCategoryManagement', () => {
-  const mockSetCategories = vi.fn()
+describe("useCategoryManagement", () => {
+  const mockSetCategories = vi.fn();
 
   beforeEach(async () => {
-    vi.clearAllMocks()
+    vi.clearAllMocks();
     const mockUseLocalStorage = vi.mocked(
-      await import('../../src/hooks/useLocalStorage')
-    ).useLocalStorage
+      await import("../../src/hooks/useLocalStorage"),
+    ).useLocalStorage;
     mockUseLocalStorage.mockReturnValue([
       [
         {
-          id: 'work',
-          name: '仕事',
-          color: '#1976d2',
-          description: '仕事関連のタスク',
-          createdAt: new Date('2024-01-01'),
-          updatedAt: new Date('2024-01-01'),
+          id: "work",
+          name: "仕事",
+          color: "#1976d2",
+          description: "仕事関連のタスク",
+          createdAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
         },
         {
-          id: 'private',
-          name: 'プライベート',
-          color: '#ff5722',
-          description: '個人的なタスク',
-          createdAt: new Date('2024-01-02'),
-          updatedAt: new Date('2024-01-02'),
+          id: "private",
+          name: "プライベート",
+          color: "#ff5722",
+          description: "個人的なタスク",
+          createdAt: new Date("2024-01-02"),
+          updatedAt: new Date("2024-01-02"),
         },
       ],
       mockSetCategories,
-    ])
-  })
+    ]);
+  });
 
   // 概要: useCategoryManagementフックの初期状態をテスト
   // 目的: カテゴリ一覧が正しく取得できることを保証
-  it('初期状態でカテゴリ一覧を返す', () => {
-    const { result } = renderHook(() => useCategoryManagement())
+  it("初期状態でカテゴリ一覧を返す", () => {
+    const { result } = renderHook(() => useCategoryManagement());
 
-    expect(result.current.categories).toHaveLength(2)
-    expect(result.current.categories[0].name).toBe('仕事')
-    expect(result.current.categories[1].name).toBe('プライベート')
-  })
+    expect(result.current.categories).toHaveLength(2);
+    expect(result.current.categories[0].name).toBe("仕事");
+    expect(result.current.categories[1].name).toBe("プライベート");
+  });
 
   // 概要: createCategory機能をテスト
   // 目的: 新規カテゴリが正しく作成・追加されることを保証
-  it('新規カテゴリを作成できる', () => {
-    const { result } = renderHook(() => useCategoryManagement())
+  it("新規カテゴリを作成できる", () => {
+    const { result } = renderHook(() => useCategoryManagement());
 
     const newCategoryData: CategoryFormData = {
-      name: '学習',
-      color: '#4caf50',
-      description: '学習関連のタスク',
-    }
+      name: "学習",
+      color: "#4caf50",
+      description: "学習関連のタスク",
+    };
 
     act(() => {
-      result.current.createCategory(newCategoryData)
-    })
+      result.current.createCategory(newCategoryData);
+    });
 
-    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function))
-  })
+    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function));
+  });
 
   // 概要: カテゴリ名の重複チェック機能をテスト
   // 目的: 同名カテゴリの作成を防止することを保証
-  it('同名のカテゴリ作成時は重複チェックする', () => {
-    const { result } = renderHook(() => useCategoryManagement())
+  it("同名のカテゴリ作成時は重複チェックする", () => {
+    const { result } = renderHook(() => useCategoryManagement());
 
     const duplicateData: CategoryFormData = {
-      name: '仕事', // 既に存在する名前
-      color: '#000000',
-    }
+      name: "仕事", // 既に存在する名前
+      color: "#000000",
+    };
 
     act(() => {
-      result.current.createCategory(duplicateData)
-    })
+      result.current.createCategory(duplicateData);
+    });
 
     // 重複する場合は何も追加されない
-    expect(mockSetCategories).not.toHaveBeenCalled()
-  })
+    expect(mockSetCategories).not.toHaveBeenCalled();
+  });
 
   // 概要: updateCategory機能をテスト
   // 目的: 既存カテゴリの情報が正しく更新されることを保証
-  it('カテゴリを更新できる', () => {
-    const { result } = renderHook(() => useCategoryManagement())
+  it("カテゴリを更新できる", () => {
+    const { result } = renderHook(() => useCategoryManagement());
 
     const updateData: CategoryFormData = {
-      name: '仕事（重要）',
-      color: '#e91e63',
-      description: '重要な仕事のタスク',
-    }
+      name: "仕事（重要）",
+      color: "#e91e63",
+      description: "重要な仕事のタスク",
+    };
 
     act(() => {
-      result.current.updateCategory('work', updateData)
-    })
+      result.current.updateCategory("work", updateData);
+    });
 
-    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function))
-  })
+    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function));
+  });
 
   // 概要: isCategoryInUse機能をテスト
   // 目的: カテゴリがTodoで使用されているかを正確に判定することを保証
-  it('使用中のカテゴリを正しく検出する', () => {
-    const { result } = renderHook(() => useCategoryManagement())
+  it("使用中のカテゴリを正しく検出する", () => {
+    const { result } = renderHook(() => useCategoryManagement());
 
-    expect(result.current.isCategoryInUse('work')).toBe(true)
-    expect(result.current.isCategoryInUse('private')).toBe(false)
-    expect(result.current.isCategoryInUse('nonexistent')).toBe(false)
-  })
+    expect(result.current.isCategoryInUse("work")).toBe(true);
+    expect(result.current.isCategoryInUse("private")).toBe(false);
+    expect(result.current.isCategoryInUse("nonexistent")).toBe(false);
+  });
 
   // 概要: 使用中カテゴリの削除制限をテスト
   // 目的: 使用中カテゴリの削除を防止することを保証
-  it('使用中のカテゴリ削除時はfalseを返す', () => {
-    const { result } = renderHook(() => useCategoryManagement())
+  it("使用中のカテゴリ削除時はfalseを返す", () => {
+    const { result } = renderHook(() => useCategoryManagement());
 
-    const deleteResult = result.current.deleteCategory('work')
+    const deleteResult = result.current.deleteCategory("work");
 
-    expect(deleteResult).toBe(false)
-    expect(mockSetCategories).not.toHaveBeenCalled()
-  })
+    expect(deleteResult).toBe(false);
+    expect(mockSetCategories).not.toHaveBeenCalled();
+  });
 
   // 概要: 未使用カテゴリの削除機能をテスト
   // 目的: 未使用カテゴリが正しく削除されることを保証
-  it('未使用のカテゴリは削除できる', () => {
-    const { result } = renderHook(() => useCategoryManagement())
+  it("未使用のカテゴリは削除できる", () => {
+    const { result } = renderHook(() => useCategoryManagement());
 
-    const deleteResult = result.current.deleteCategory('private')
+    const deleteResult = result.current.deleteCategory("private");
 
-    expect(deleteResult).toBe(true)
-    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function))
-  })
+    expect(deleteResult).toBe(true);
+    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function));
+  });
 
   // 概要: 存在しないカテゴリの削除処理をテスト
   // 目的: 存在しないカテゴリID指定時の適切な処理を保証
-  it('存在しないカテゴリの削除時はfalseを返す', () => {
-    const { result } = renderHook(() => useCategoryManagement())
+  it("存在しないカテゴリの削除時はfalseを返す", () => {
+    const { result } = renderHook(() => useCategoryManagement());
 
-    const deleteResult = result.current.deleteCategory('nonexistent')
+    const deleteResult = result.current.deleteCategory("nonexistent");
 
-    expect(deleteResult).toBe(false)
-    expect(mockSetCategories).not.toHaveBeenCalled()
-  })
-})
+    expect(deleteResult).toBe(false);
+    expect(mockSetCategories).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/hooks/useDarkMode.test.ts
+++ b/frontend/__tests__/hooks/useDarkMode.test.ts
@@ -1,6 +1,6 @@
-import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { useDarkMode } from '../../src/hooks/useDarkMode'
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useDarkMode } from "../../src/hooks/useDarkMode";
 
 // localStorageのモック
 const localStorageMock = {
@@ -8,169 +8,169 @@ const localStorageMock = {
   setItem: vi.fn(),
   removeItem: vi.fn(),
   clear: vi.fn(),
-}
+};
 
-Object.defineProperty(window, 'localStorage', {
+Object.defineProperty(window, "localStorage", {
   value: localStorageMock,
-})
+});
 
 // matchMediaのモック
-const matchMediaMock = vi.fn()
-Object.defineProperty(window, 'matchMedia', {
+const matchMediaMock = vi.fn();
+Object.defineProperty(window, "matchMedia", {
   value: matchMediaMock,
-})
+});
 
-describe('useDarkMode', () => {
+describe("useDarkMode", () => {
   beforeEach(() => {
     // 各テスト前にモックをリセット
-    localStorageMock.getItem.mockClear()
-    localStorageMock.setItem.mockClear()
-    matchMediaMock.mockClear()
-  })
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    matchMediaMock.mockClear();
+  });
 
   // 概要: 初期状態でシステム設定を検出することをテスト
   // 目的: ユーザーのシステム設定（ダークモード）を自動検出することを保証
-  it('detects system dark mode preference initially', () => {
-    localStorageMock.getItem.mockReturnValue(null)
+  it("detects system dark mode preference initially", () => {
+    localStorageMock.getItem.mockReturnValue(null);
     matchMediaMock.mockReturnValue({
       matches: true,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-    })
+    });
 
-    const { result } = renderHook(() => useDarkMode())
+    const { result } = renderHook(() => useDarkMode());
 
-    expect(result.current.isDarkMode).toBe(true)
-    expect(matchMediaMock).toHaveBeenCalledWith('(prefers-color-scheme: dark)')
-  })
+    expect(result.current.isDarkMode).toBe(true);
+    expect(matchMediaMock).toHaveBeenCalledWith("(prefers-color-scheme: dark)");
+  });
 
   // 概要: システム設定がライトモードの場合の初期状態をテスト
   // 目的: ライトモードのシステム設定が正しく検出されることを確認
-  it('detects system light mode preference initially', () => {
-    localStorageMock.getItem.mockReturnValue(null)
+  it("detects system light mode preference initially", () => {
+    localStorageMock.getItem.mockReturnValue(null);
     matchMediaMock.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-    })
+    });
 
-    const { result } = renderHook(() => useDarkMode())
+    const { result } = renderHook(() => useDarkMode());
 
-    expect(result.current.isDarkMode).toBe(false)
-  })
+    expect(result.current.isDarkMode).toBe(false);
+  });
 
   // 概要: localStorageに保存された設定を優先することをテスト
   // 目的: ユーザーの明示的な選択がシステム設定より優先されることを保証
-  it('uses stored preference over system preference', () => {
-    localStorageMock.getItem.mockReturnValue(JSON.stringify(true))
+  it("uses stored preference over system preference", () => {
+    localStorageMock.getItem.mockReturnValue(JSON.stringify(true));
     matchMediaMock.mockReturnValue({
       matches: false, // システムはライトモード
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-    })
+    });
 
-    const { result } = renderHook(() => useDarkMode())
+    const { result } = renderHook(() => useDarkMode());
 
-    expect(result.current.isDarkMode).toBe(true) // ストレージの設定を使用
-  })
+    expect(result.current.isDarkMode).toBe(true); // ストレージの設定を使用
+  });
 
   // 概要: ダークモードのトグル機能をテスト
   // 目的: toggleDarkMode関数が正しく動作することを確認
-  it('toggles dark mode and saves to localStorage', () => {
-    localStorageMock.getItem.mockReturnValue(null)
+  it("toggles dark mode and saves to localStorage", () => {
+    localStorageMock.getItem.mockReturnValue(null);
     matchMediaMock.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-    })
+    });
 
-    const { result } = renderHook(() => useDarkMode())
+    const { result } = renderHook(() => useDarkMode());
 
-    expect(result.current.isDarkMode).toBe(false)
+    expect(result.current.isDarkMode).toBe(false);
 
     act(() => {
-      result.current.toggleDarkMode()
-    })
+      result.current.toggleDarkMode();
+    });
 
-    expect(result.current.isDarkMode).toBe(true)
+    expect(result.current.isDarkMode).toBe(true);
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'darkMode',
-      JSON.stringify(true)
-    )
-  })
+      "darkMode",
+      JSON.stringify(true),
+    );
+  });
 
   // 概要: 手動設定機能をテスト
   // 目的: setDarkMode関数で明示的にモードを設定できることを確認
-  it('allows manual setting of dark mode', () => {
-    localStorageMock.getItem.mockReturnValue(null)
+  it("allows manual setting of dark mode", () => {
+    localStorageMock.getItem.mockReturnValue(null);
     matchMediaMock.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-    })
+    });
 
-    const { result } = renderHook(() => useDarkMode())
-
-    act(() => {
-      result.current.setDarkMode(true)
-    })
-
-    expect(result.current.isDarkMode).toBe(true)
-    expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'darkMode',
-      JSON.stringify(true)
-    )
+    const { result } = renderHook(() => useDarkMode());
 
     act(() => {
-      result.current.setDarkMode(false)
-    })
+      result.current.setDarkMode(true);
+    });
 
-    expect(result.current.isDarkMode).toBe(false)
+    expect(result.current.isDarkMode).toBe(true);
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'darkMode',
-      JSON.stringify(false)
-    )
-  })
+      "darkMode",
+      JSON.stringify(true),
+    );
+
+    act(() => {
+      result.current.setDarkMode(false);
+    });
+
+    expect(result.current.isDarkMode).toBe(false);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "darkMode",
+      JSON.stringify(false),
+    );
+  });
 
   // 概要: システム設定変更時の動的更新をテスト
   // 目的: ユーザーがシステム設定を変更したときの自動追従を確認
-  it('updates when system preference changes', () => {
-    const mockAddEventListener = vi.fn()
-    const mockRemoveEventListener = vi.fn()
+  it("updates when system preference changes", () => {
+    const mockAddEventListener = vi.fn();
+    const mockRemoveEventListener = vi.fn();
 
-    localStorageMock.getItem.mockReturnValue(null)
+    localStorageMock.getItem.mockReturnValue(null);
     matchMediaMock.mockReturnValue({
       matches: false,
       addEventListener: mockAddEventListener,
       removeEventListener: mockRemoveEventListener,
-    })
+    });
 
-    const { unmount } = renderHook(() => useDarkMode())
+    const { unmount } = renderHook(() => useDarkMode());
 
     expect(mockAddEventListener).toHaveBeenCalledWith(
-      'change',
-      expect.any(Function)
-    )
+      "change",
+      expect.any(Function),
+    );
 
-    unmount()
+    unmount();
 
     expect(mockRemoveEventListener).toHaveBeenCalledWith(
-      'change',
-      expect.any(Function)
-    )
-  })
+      "change",
+      expect.any(Function),
+    );
+  });
 
   // 概要: エラー処理のテスト
   // 目的: matchMediaが利用不可能な環境でも正常に動作することを確認
-  it('handles environments without matchMedia', () => {
-    localStorageMock.getItem.mockReturnValue(null)
+  it("handles environments without matchMedia", () => {
+    localStorageMock.getItem.mockReturnValue(null);
     matchMediaMock.mockImplementation(() => {
-      throw new Error('matchMedia not supported')
-    })
+      throw new Error("matchMedia not supported");
+    });
 
-    const { result } = renderHook(() => useDarkMode())
+    const { result } = renderHook(() => useDarkMode());
 
     // エラーが発生してもデフォルト値（false）が返される
-    expect(result.current.isDarkMode).toBe(false)
-  })
-})
+    expect(result.current.isDarkMode).toBe(false);
+  });
+});

--- a/frontend/__tests__/hooks/useEditTodo.test.ts
+++ b/frontend/__tests__/hooks/useEditTodo.test.ts
@@ -1,148 +1,148 @@
-import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import { useEditTodo } from '../../src/hooks/useEditTodo'
-import type { Todo, EditTodoData } from '../../src/types/todo'
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useEditTodo } from "../../src/hooks/useEditTodo";
+import type { Todo, EditTodoData } from "../../src/types/todo";
 
 const mockTodo: Todo = {
-  id: '1',
-  text: 'Test todo',
+  id: "1",
+  text: "Test todo",
   completed: false,
-  createdAt: new Date('2024-01-01'),
-  categoryId: 'cat1',
-  tags: ['tag1', 'tag2'],
+  createdAt: new Date("2024-01-01"),
+  categoryId: "cat1",
+  tags: ["tag1", "tag2"],
   order: 0,
-}
+};
 
-describe('useEditTodo', () => {
+describe("useEditTodo", () => {
   // 概要: useEditTodoフックの初期状態をテスト
   // 目的: フックが編集状態でない状態で初期化されることを保証
-  it('initializes with correct default state', () => {
-    const onEdit = vi.fn()
-    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit))
+  it("initializes with correct default state", () => {
+    const onEdit = vi.fn();
+    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit));
 
-    expect(result.current.isEditing).toBe(false)
+    expect(result.current.isEditing).toBe(false);
     expect(result.current.editData).toEqual({
       text: mockTodo.text,
       categoryId: mockTodo.categoryId,
       tags: mockTodo.tags,
-    })
-  })
+    });
+  });
 
   // 概要: 編集開始機能をテスト
   // 目的: startEdit関数が編集状態を正しくtrueに設定することを保証
-  it('enters edit mode when startEdit is called', () => {
-    const onEdit = vi.fn()
-    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit))
+  it("enters edit mode when startEdit is called", () => {
+    const onEdit = vi.fn();
+    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit));
 
     act(() => {
-      result.current.startEdit()
-    })
+      result.current.startEdit();
+    });
 
-    expect(result.current.isEditing).toBe(true)
-  })
+    expect(result.current.isEditing).toBe(true);
+  });
 
   // 概要: 編集キャンセル機能をテスト
   // 目的: cancelEdit関数が編集状態を正しくfalseに設定し、データをリセットすることを保証
-  it('cancels edit mode and resets data when cancelEdit is called', () => {
-    const onEdit = vi.fn()
-    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit))
+  it("cancels edit mode and resets data when cancelEdit is called", () => {
+    const onEdit = vi.fn();
+    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit));
 
     act(() => {
-      result.current.startEdit()
-    })
+      result.current.startEdit();
+    });
 
     act(() => {
-      result.current.updateEditData({ text: 'Modified text' })
-    })
+      result.current.updateEditData({ text: "Modified text" });
+    });
 
     act(() => {
-      result.current.cancelEdit()
-    })
+      result.current.cancelEdit();
+    });
 
-    expect(result.current.isEditing).toBe(false)
-    expect(result.current.editData.text).toBe(mockTodo.text)
-  })
+    expect(result.current.isEditing).toBe(false);
+    expect(result.current.editData.text).toBe(mockTodo.text);
+  });
 
   // 概要: 編集データ更新機能をテスト
   // 目的: updateEditData関数が編集データを正しく更新することを保証
-  it('updates edit data when updateEditData is called', () => {
-    const onEdit = vi.fn()
-    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit))
+  it("updates edit data when updateEditData is called", () => {
+    const onEdit = vi.fn();
+    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit));
 
     const newData: Partial<EditTodoData> = {
-      text: 'Updated text',
-      tags: ['newtag'],
-    }
+      text: "Updated text",
+      tags: ["newtag"],
+    };
 
     act(() => {
-      result.current.updateEditData(newData)
-    })
+      result.current.updateEditData(newData);
+    });
 
-    expect(result.current.editData.text).toBe('Updated text')
-    expect(result.current.editData.tags).toEqual(['newtag'])
-    expect(result.current.editData.categoryId).toBe(mockTodo.categoryId)
-  })
+    expect(result.current.editData.text).toBe("Updated text");
+    expect(result.current.editData.tags).toEqual(["newtag"]);
+    expect(result.current.editData.categoryId).toBe(mockTodo.categoryId);
+  });
 
   // 概要: 編集保存機能をテスト
   // 目的: saveEdit関数がonEdit callbackを呼び出し、編集モードを終了することを保証
-  it('saves edit data and exits edit mode when saveEdit is called', () => {
-    const onEdit = vi.fn()
-    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit))
+  it("saves edit data and exits edit mode when saveEdit is called", () => {
+    const onEdit = vi.fn();
+    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit));
 
     act(() => {
-      result.current.startEdit()
-    })
+      result.current.startEdit();
+    });
 
     const updatedData: Partial<EditTodoData> = {
-      text: 'Saved text',
-    }
+      text: "Saved text",
+    };
 
     act(() => {
-      result.current.updateEditData(updatedData)
-    })
+      result.current.updateEditData(updatedData);
+    });
 
     act(() => {
-      result.current.saveEdit()
-    })
+      result.current.saveEdit();
+    });
 
     expect(onEdit).toHaveBeenCalledWith(mockTodo.id, {
-      text: 'Saved text',
+      text: "Saved text",
       categoryId: mockTodo.categoryId,
       tags: mockTodo.tags,
-    })
-    expect(result.current.isEditing).toBe(false)
-  })
+    });
+    expect(result.current.isEditing).toBe(false);
+  });
 
   // 概要: 空のテキストでの保存防止をテスト
   // 目的: 空またはwhitespaceのみのテキストでsaveEditが呼ばれた際に保存されないことを保証
-  it('does not save when text is empty or only whitespace', () => {
-    const onEdit = vi.fn()
-    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit))
+  it("does not save when text is empty or only whitespace", () => {
+    const onEdit = vi.fn();
+    const { result } = renderHook(() => useEditTodo(mockTodo, onEdit));
 
     act(() => {
-      result.current.startEdit()
-    })
+      result.current.startEdit();
+    });
 
     act(() => {
-      result.current.updateEditData({ text: '   ' })
-    })
+      result.current.updateEditData({ text: "   " });
+    });
 
     act(() => {
-      result.current.saveEdit()
-    })
+      result.current.saveEdit();
+    });
 
-    expect(onEdit).not.toHaveBeenCalled()
-    expect(result.current.isEditing).toBe(true)
-
-    act(() => {
-      result.current.updateEditData({ text: '' })
-    })
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(result.current.isEditing).toBe(true);
 
     act(() => {
-      result.current.saveEdit()
-    })
+      result.current.updateEditData({ text: "" });
+    });
 
-    expect(onEdit).not.toHaveBeenCalled()
-    expect(result.current.isEditing).toBe(true)
-  })
-})
+    act(() => {
+      result.current.saveEdit();
+    });
+
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(result.current.isEditing).toBe(true);
+  });
+});

--- a/frontend/__tests__/hooks/useFilters.test.ts
+++ b/frontend/__tests__/hooks/useFilters.test.ts
@@ -1,238 +1,242 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
-import type { Todo } from '../../src/types/todo'
-import { useFilters } from '../../src/hooks/useFilters'
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Todo } from "../../src/types/todo";
+import { useFilters } from "../../src/hooks/useFilters";
 
 const mockTodos: Todo[] = [
   {
-    id: '1',
-    text: 'Buy groceries',
+    id: "1",
+    text: "Buy groceries",
     completed: false,
-    createdAt: new Date('2025-01-01'),
-    categoryId: 'personal',
-    tags: ['shopping', 'urgent'],
+    createdAt: new Date("2025-01-01"),
+    categoryId: "personal",
+    tags: ["shopping", "urgent"],
   },
   {
-    id: '2',
-    text: 'Fix bug in application',
+    id: "2",
+    text: "Fix bug in application",
     completed: true,
-    createdAt: new Date('2025-01-02'),
-    categoryId: 'work',
-    tags: ['development', 'urgent'],
+    createdAt: new Date("2025-01-02"),
+    categoryId: "work",
+    tags: ["development", "urgent"],
   },
   {
-    id: '3',
-    text: 'Read book',
+    id: "3",
+    text: "Read book",
     completed: false,
-    createdAt: new Date('2025-01-03'),
-    categoryId: 'personal',
-    tags: ['learning'],
+    createdAt: new Date("2025-01-03"),
+    categoryId: "personal",
+    tags: ["learning"],
   },
   {
-    id: '4',
-    text: 'Team meeting preparation',
+    id: "4",
+    text: "Team meeting preparation",
     completed: true,
-    createdAt: new Date('2025-01-04'),
-    categoryId: 'work',
-    tags: ['meeting', 'preparation'],
+    createdAt: new Date("2025-01-04"),
+    categoryId: "work",
+    tags: ["meeting", "preparation"],
   },
-]
+];
 
-describe('useFilters', () => {
+describe("useFilters", () => {
   beforeEach(() => {
-    localStorage.clear()
-  })
+    localStorage.clear();
+  });
 
   // 概要: 初期状態でフィルター機能の動作を確認
   // 目的: フックが正しく初期化され、全てのTodoが表示されることを保証
-  it('初期状態では全てのTodoが表示される', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("初期状態では全てのTodoが表示される", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
-    expect(result.current.filters.completionStatus).toBe('all')
-    expect(result.current.filters.categoryIds).toEqual([])
-    expect(result.current.filters.tags).toEqual([])
-    expect(result.current.filters.tagCondition).toBe('any')
-    expect(result.current.filters.searchText).toBe('')
-    expect(result.current.filteredTodos).toEqual(mockTodos)
-    expect(result.current.activeFilterCount).toBe(0)
-  })
+    expect(result.current.filters.completionStatus).toBe("all");
+    expect(result.current.filters.categoryIds).toEqual([]);
+    expect(result.current.filters.tags).toEqual([]);
+    expect(result.current.filters.tagCondition).toBe("any");
+    expect(result.current.filters.searchText).toBe("");
+    expect(result.current.filteredTodos).toEqual(mockTodos);
+    expect(result.current.activeFilterCount).toBe(0);
+  });
 
   // 概要: 完了状態フィルターの動作確認
   // 目的: 完了済みのTodoのみが正しくフィルタリングされることを保証
-  it('完了状態でフィルタリングできる', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("完了状態でフィルタリングできる", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
-      result.current.updateFilters({ completionStatus: 'completed' })
-    })
+      result.current.updateFilters({ completionStatus: "completed" });
+    });
 
-    expect(result.current.filteredTodos).toHaveLength(2)
-    expect(result.current.filteredTodos.every(todo => todo.completed)).toBe(
-      true
-    )
-    expect(result.current.activeFilterCount).toBe(1)
-  })
+    expect(result.current.filteredTodos).toHaveLength(2);
+    expect(result.current.filteredTodos.every((todo) => todo.completed)).toBe(
+      true,
+    );
+    expect(result.current.activeFilterCount).toBe(1);
+  });
 
   // 概要: 未完了状態フィルターの動作確認
   // 目的: 未完了のTodoのみが正しくフィルタリングされることを保証
-  it('未完了状態でフィルタリングできる', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("未完了状態でフィルタリングできる", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
-      result.current.updateFilters({ completionStatus: 'incomplete' })
-    })
+      result.current.updateFilters({ completionStatus: "incomplete" });
+    });
 
-    expect(result.current.filteredTodos).toHaveLength(2)
-    expect(result.current.filteredTodos.every(todo => !todo.completed)).toBe(
-      true
-    )
-    expect(result.current.activeFilterCount).toBe(1)
-  })
+    expect(result.current.filteredTodos).toHaveLength(2);
+    expect(result.current.filteredTodos.every((todo) => !todo.completed)).toBe(
+      true,
+    );
+    expect(result.current.activeFilterCount).toBe(1);
+  });
 
   // 概要: カテゴリフィルターの動作確認
   // 目的: 指定したカテゴリのTodoのみが正しくフィルタリングされることを保証
-  it('カテゴリでフィルタリングできる', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("カテゴリでフィルタリングできる", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
-      result.current.updateFilters({ categoryIds: ['work'] })
-    })
+      result.current.updateFilters({ categoryIds: ["work"] });
+    });
 
-    expect(result.current.filteredTodos).toHaveLength(2)
+    expect(result.current.filteredTodos).toHaveLength(2);
     expect(
-      result.current.filteredTodos.every(todo => todo.categoryId === 'work')
-    ).toBe(true)
-    expect(result.current.activeFilterCount).toBe(1)
-  })
+      result.current.filteredTodos.every((todo) => todo.categoryId === "work"),
+    ).toBe(true);
+    expect(result.current.activeFilterCount).toBe(1);
+  });
 
   // 概要: タグフィルター（OR条件）の動作確認
   // 目的: 指定したタグのいずれかを持つTodoが正しくフィルタリングされることを保証
-  it('タグでフィルタリングできる（any条件）', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("タグでフィルタリングできる（any条件）", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
-      result.current.updateFilters({ tags: ['urgent'], tagCondition: 'any' })
-    })
+      result.current.updateFilters({ tags: ["urgent"], tagCondition: "any" });
+    });
 
-    expect(result.current.filteredTodos).toHaveLength(2)
+    expect(result.current.filteredTodos).toHaveLength(2);
     expect(
-      result.current.filteredTodos.every(todo => todo.tags.includes('urgent'))
-    ).toBe(true)
-    expect(result.current.activeFilterCount).toBe(1)
-  })
+      result.current.filteredTodos.every((todo) =>
+        todo.tags.includes("urgent"),
+      ),
+    ).toBe(true);
+    expect(result.current.activeFilterCount).toBe(1);
+  });
 
   // 概要: タグフィルター（AND条件）の動作確認
   // 目的: 指定したタグを全て持つTodoが正しくフィルタリングされることを保証
-  it('タグでフィルタリングできる（all条件）', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("タグでフィルタリングできる（all条件）", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
       result.current.updateFilters({
-        tags: ['urgent', 'shopping'],
-        tagCondition: 'all',
-      })
-    })
+        tags: ["urgent", "shopping"],
+        tagCondition: "all",
+      });
+    });
 
-    expect(result.current.filteredTodos).toHaveLength(1)
-    expect(result.current.filteredTodos[0].id).toBe('1')
-    expect(result.current.activeFilterCount).toBe(1)
-  })
+    expect(result.current.filteredTodos).toHaveLength(1);
+    expect(result.current.filteredTodos[0].id).toBe("1");
+    expect(result.current.activeFilterCount).toBe(1);
+  });
 
   // 概要: テキスト検索フィルターの動作確認
   // 目的: 指定したテキストを含むTodoが正しくフィルタリングされることを保証
-  it('テキスト検索でフィルタリングできる', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("テキスト検索でフィルタリングできる", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
-      result.current.updateFilters({ searchText: 'bug' })
-    })
+      result.current.updateFilters({ searchText: "bug" });
+    });
 
-    expect(result.current.filteredTodos).toHaveLength(1)
-    expect(result.current.filteredTodos[0].text).toContain('bug')
-    expect(result.current.activeFilterCount).toBe(1)
-  })
+    expect(result.current.filteredTodos).toHaveLength(1);
+    expect(result.current.filteredTodos[0].text).toContain("bug");
+    expect(result.current.activeFilterCount).toBe(1);
+  });
 
   // 概要: 複数フィルターの組み合わせ動作確認
   // 目的: 複数の条件を同時に適用したフィルタリングが正しく動作することを保証
-  it('複数フィルターの組み合わせが可能', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("複数フィルターの組み合わせが可能", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
       result.current.updateFilters({
-        completionStatus: 'incomplete',
-        categoryIds: ['personal'],
-      })
-    })
+        completionStatus: "incomplete",
+        categoryIds: ["personal"],
+      });
+    });
 
-    expect(result.current.filteredTodos).toHaveLength(2)
+    expect(result.current.filteredTodos).toHaveLength(2);
     expect(
       result.current.filteredTodos.every(
-        todo => !todo.completed && todo.categoryId === 'personal'
-      )
-    ).toBe(true)
-    expect(result.current.activeFilterCount).toBe(2)
-  })
+        (todo) => !todo.completed && todo.categoryId === "personal",
+      ),
+    ).toBe(true);
+    expect(result.current.activeFilterCount).toBe(2);
+  });
 
   // 概要: フィルターリセット機能の動作確認
   // 目的: reupdateFilters関数が全てのフィルターを初期状態に戻すことを保証
-  it('フィルターをリセットできる', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("フィルターをリセットできる", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
       result.current.updateFilters({
-        completionStatus: 'completed',
-        categoryIds: ['work'],
-        searchText: 'test',
-      })
-    })
+        completionStatus: "completed",
+        categoryIds: ["work"],
+        searchText: "test",
+      });
+    });
 
-    expect(result.current.activeFilterCount).toBe(3)
+    expect(result.current.activeFilterCount).toBe(3);
 
     act(() => {
-      result.current.resetFilters()
-    })
+      result.current.resetFilters();
+    });
 
-    expect(result.current.filters.completionStatus).toBe('all')
-    expect(result.current.filters.categoryIds).toEqual([])
-    expect(result.current.filters.searchText).toBe('')
-    expect(result.current.filteredTodos).toEqual(mockTodos)
-    expect(result.current.activeFilterCount).toBe(0)
-  })
+    expect(result.current.filters.completionStatus).toBe("all");
+    expect(result.current.filters.categoryIds).toEqual([]);
+    expect(result.current.filters.searchText).toBe("");
+    expect(result.current.filteredTodos).toEqual(mockTodos);
+    expect(result.current.activeFilterCount).toBe(0);
+  });
 
   // 概要: フィルター状態の永続化機能の動作確認
   // 目的: フィルター設定がlocalStorageに正しく保存されることを保証
-  it('フィルター状態がlocalStorageに保存される', () => {
-    const { result } = renderHook(() => useFilters(mockTodos))
+  it("フィルター状態がlocalStorageに保存される", () => {
+    const { result } = renderHook(() => useFilters(mockTodos));
 
     act(() => {
-      result.current.updateFilters({ completionStatus: 'completed' })
-    })
+      result.current.updateFilters({ completionStatus: "completed" });
+    });
 
-    const savedFilters = JSON.parse(localStorage.getItem('todoFilters') || '{}')
-    expect(savedFilters.completionStatus).toBe('completed')
-  })
+    const savedFilters = JSON.parse(
+      localStorage.getItem("todoFilters") || "{}",
+    );
+    expect(savedFilters.completionStatus).toBe("completed");
+  });
 
   // 概要: 永続化されたフィルター状態の復元機能の動作確認
   // 目的: localStorageから保存されたフィルター設定が正しく復元されることを保証
-  it('localStorageから保存されたフィルター状態を復元する', () => {
+  it("localStorageから保存されたフィルター状態を復元する", () => {
     const savedFilters = {
-      completionStatus: 'completed',
-      categoryIds: ['work'],
+      completionStatus: "completed",
+      categoryIds: ["work"],
       tags: [],
-      tagCondition: 'any',
-      searchText: '',
-    }
-    localStorage.setItem('todoFilters', JSON.stringify(savedFilters))
+      tagCondition: "any",
+      searchText: "",
+    };
+    localStorage.setItem("todoFilters", JSON.stringify(savedFilters));
 
-    const { result } = renderHook(() => useFilters(mockTodos))
+    const { result } = renderHook(() => useFilters(mockTodos));
 
-    expect(result.current.filters.completionStatus).toBe('completed')
-    expect(result.current.filters.categoryIds).toEqual(['work'])
-    expect(result.current.filteredTodos).toHaveLength(2)
+    expect(result.current.filters.completionStatus).toBe("completed");
+    expect(result.current.filters.categoryIds).toEqual(["work"]);
+    expect(result.current.filteredTodos).toHaveLength(2);
     expect(
       result.current.filteredTodos.every(
-        todo => todo.completed && todo.categoryId === 'work'
-      )
-    ).toBe(true)
-  })
-})
+        (todo) => todo.completed && todo.categoryId === "work",
+      ),
+    ).toBe(true);
+  });
+});

--- a/frontend/__tests__/hooks/useLocalStorage.test.ts
+++ b/frontend/__tests__/hooks/useLocalStorage.test.ts
@@ -1,6 +1,6 @@
-import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { useLocalStorage } from '../../src/hooks/useLocalStorage'
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useLocalStorage } from "../../src/hooks/useLocalStorage";
 
 // localStorageのモック
 const localStorageMock = {
@@ -8,118 +8,118 @@ const localStorageMock = {
   setItem: vi.fn(),
   removeItem: vi.fn(),
   clear: vi.fn(),
-}
+};
 
 // グローバルオブジェクトのlocalStorageをモックで置き換え
-Object.defineProperty(window, 'localStorage', {
+Object.defineProperty(window, "localStorage", {
   value: localStorageMock,
-})
+});
 
-describe('useLocalStorage', () => {
+describe("useLocalStorage", () => {
   beforeEach(() => {
     // 各テスト前にモックをリセット
-    localStorageMock.getItem.mockClear()
-    localStorageMock.setItem.mockClear()
-    localStorageMock.removeItem.mockClear()
-    localStorageMock.clear.mockClear()
-  })
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    localStorageMock.removeItem.mockClear();
+    localStorageMock.clear.mockClear();
+  });
 
   // 概要: 初期値が正しく設定されることをテスト
   // 目的: localStorageに値がない場合、初期値が使用されることを確認
-  it('returns initial value when localStorage is empty', () => {
-    localStorageMock.getItem.mockReturnValue(null)
+  it("returns initial value when localStorage is empty", () => {
+    localStorageMock.getItem.mockReturnValue(null);
 
     const { result } = renderHook(() =>
-      useLocalStorage('test-key', 'initial-value')
-    )
+      useLocalStorage("test-key", "initial-value"),
+    );
 
-    expect(result.current[0]).toBe('initial-value')
-    expect(localStorageMock.getItem).toHaveBeenCalledWith('test-key')
-  })
+    expect(result.current[0]).toBe("initial-value");
+    expect(localStorageMock.getItem).toHaveBeenCalledWith("test-key");
+  });
 
   // 概要: localStorageから既存の値を正しく読み込むことをテスト
   // 目的: 保存された値が正しく復元されることを確認
-  it('returns stored value from localStorage', () => {
-    localStorageMock.getItem.mockReturnValue(JSON.stringify('stored-value'))
+  it("returns stored value from localStorage", () => {
+    localStorageMock.getItem.mockReturnValue(JSON.stringify("stored-value"));
 
     const { result } = renderHook(() =>
-      useLocalStorage('test-key', 'initial-value')
-    )
+      useLocalStorage("test-key", "initial-value"),
+    );
 
-    expect(result.current[0]).toBe('stored-value')
-    expect(localStorageMock.getItem).toHaveBeenCalledWith('test-key')
-  })
+    expect(result.current[0]).toBe("stored-value");
+    expect(localStorageMock.getItem).toHaveBeenCalledWith("test-key");
+  });
 
   // 概要: 値を更新したときにlocalStorageに保存されることをテスト
   // 目的: setValue関数が正しく動作することを確認
-  it('updates localStorage when value is set', () => {
-    localStorageMock.getItem.mockReturnValue(null)
+  it("updates localStorage when value is set", () => {
+    localStorageMock.getItem.mockReturnValue(null);
 
     const { result } = renderHook(() =>
-      useLocalStorage('test-key', 'initial-value')
-    )
+      useLocalStorage("test-key", "initial-value"),
+    );
 
     act(() => {
-      result.current[1]('new-value')
-    })
+      result.current[1]("new-value");
+    });
 
-    expect(result.current[0]).toBe('new-value')
+    expect(result.current[0]).toBe("new-value");
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'test-key',
-      JSON.stringify('new-value')
-    )
-  })
+      "test-key",
+      JSON.stringify("new-value"),
+    );
+  });
 
   // 概要: 関数型の値更新が正しく動作することをテスト
   // 目的: setValue((prev) => newValue)の形式が正しく動作することを確認
-  it('updates value using function updater', () => {
-    localStorageMock.getItem.mockReturnValue(JSON.stringify(5))
+  it("updates value using function updater", () => {
+    localStorageMock.getItem.mockReturnValue(JSON.stringify(5));
 
-    const { result } = renderHook(() => useLocalStorage('test-key', 0))
+    const { result } = renderHook(() => useLocalStorage("test-key", 0));
 
     act(() => {
-      result.current[1]((prev: number) => prev + 1)
-    })
+      result.current[1]((prev: number) => prev + 1);
+    });
 
-    expect(result.current[0]).toBe(6)
+    expect(result.current[0]).toBe(6);
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
-      'test-key',
-      JSON.stringify(6)
-    )
-  })
+      "test-key",
+      JSON.stringify(6),
+    );
+  });
 
   // 概要: オブジェクトや配列が正しく保存・復元されることをテスト
   // 目的: JSON.stringify/parseが正しく動作することを確認
-  it('handles complex objects correctly', () => {
-    const complexObject = { items: ['todo1', 'todo2'], count: 2 }
-    localStorageMock.getItem.mockReturnValue(JSON.stringify(complexObject))
+  it("handles complex objects correctly", () => {
+    const complexObject = { items: ["todo1", "todo2"], count: 2 };
+    localStorageMock.getItem.mockReturnValue(JSON.stringify(complexObject));
 
     const { result } = renderHook(() =>
-      useLocalStorage('test-key', { items: [], count: 0 })
-    )
+      useLocalStorage("test-key", { items: [], count: 0 }),
+    );
 
-    expect(result.current[0]).toEqual(complexObject)
-  })
+    expect(result.current[0]).toEqual(complexObject);
+  });
 
   // 概要: localStorageでエラーが発生した場合の処理をテスト
   // 目的: エラーハンドリングが正しく動作することを確認
-  it('handles localStorage errors gracefully', () => {
+  it("handles localStorage errors gracefully", () => {
     localStorageMock.getItem.mockImplementation(() => {
-      throw new Error('Storage error')
-    })
+      throw new Error("Storage error");
+    });
 
     // コンソール警告をモック
     const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {})
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
 
     const { result } = renderHook(() =>
-      useLocalStorage('test-key', 'fallback-value')
-    )
+      useLocalStorage("test-key", "fallback-value"),
+    );
 
-    expect(result.current[0]).toBe('fallback-value')
-    expect(consoleWarnSpy).toHaveBeenCalled()
+    expect(result.current[0]).toBe("fallback-value");
+    expect(consoleWarnSpy).toHaveBeenCalled();
 
-    consoleWarnSpy.mockRestore()
-  })
-})
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/frontend/__tests__/hooks/useTodoSorting.test.ts
+++ b/frontend/__tests__/hooks/useTodoSorting.test.ts
@@ -1,149 +1,149 @@
-import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
-import type { DragEndEvent } from '@dnd-kit/core'
-import type { Todo } from '../../src/types/todo'
-import { useTodoSorting } from '../../src/hooks/useTodoSorting'
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import type { DragEndEvent } from "@dnd-kit/core";
+import type { Todo } from "../../src/types/todo";
+import { useTodoSorting } from "../../src/hooks/useTodoSorting";
 
-describe('useTodoSorting', () => {
+describe("useTodoSorting", () => {
   const mockTodos: Todo[] = [
     {
-      id: '1',
-      text: 'First todo',
+      id: "1",
+      text: "First todo",
       completed: false,
-      createdAt: new Date('2023-01-01'),
-      categoryId: 'category1',
-      tags: ['tag1'],
+      createdAt: new Date("2023-01-01"),
+      categoryId: "category1",
+      tags: ["tag1"],
       order: 0,
     },
     {
-      id: '2',
-      text: 'Second todo',
+      id: "2",
+      text: "Second todo",
       completed: false,
-      createdAt: new Date('2023-01-02'),
-      categoryId: 'category2',
-      tags: ['tag2'],
+      createdAt: new Date("2023-01-02"),
+      categoryId: "category2",
+      tags: ["tag2"],
       order: 1,
     },
     {
-      id: '3',
-      text: 'Third todo',
+      id: "3",
+      text: "Third todo",
       completed: true,
-      createdAt: new Date('2023-01-03'),
-      categoryId: 'category1',
-      tags: ['tag1'],
+      createdAt: new Date("2023-01-03"),
+      categoryId: "category1",
+      tags: ["tag1"],
       order: 2,
     },
-  ]
+  ];
 
   // 概要: useTodoSortingフックが正しく初期化されることをテスト
   // 目的: フックが基本的な機能を提供し、初期状態でTodoリストが正しく設定されることを保証
-  it('initializes with todos sorted by order', () => {
-    const { result } = renderHook(() => useTodoSorting(mockTodos))
+  it("initializes with todos sorted by order", () => {
+    const { result } = renderHook(() => useTodoSorting(mockTodos));
 
-    expect(result.current.sortedTodos).toEqual(mockTodos)
-    expect(result.current.sortedTodos).toHaveLength(3)
-  })
+    expect(result.current.sortedTodos).toEqual(mockTodos);
+    expect(result.current.sortedTodos).toHaveLength(3);
+  });
 
   // 概要: ドラッグ&ドロップによる並び順変更処理をテスト
   // 目的: アイテムの順序が正しく更新され、onReorderコールバックが適切に呼ばれることを保証
-  it('handles drag end and reorders todos correctly', () => {
-    let reorderedTodos: Todo[] = []
+  it("handles drag end and reorders todos correctly", () => {
+    let reorderedTodos: Todo[] = [];
     const onReorder = (todos: Todo[]) => {
-      reorderedTodos = todos
-    }
+      reorderedTodos = todos;
+    };
 
-    const { result } = renderHook(() => useTodoSorting(mockTodos, onReorder))
+    const { result } = renderHook(() => useTodoSorting(mockTodos, onReorder));
 
     act(() => {
       // First item (index 0) to third position (index 2) - simplified event object
       const dragEndEvent = {
-        active: { id: '1' },
-        over: { id: '3' },
-      } as DragEndEvent
-      result.current.handleDragEnd(dragEndEvent)
-    })
+        active: { id: "1" },
+        over: { id: "3" },
+      } as DragEndEvent;
+      result.current.handleDragEnd(dragEndEvent);
+    });
 
     // orderフィールドが更新されることを確認
-    expect(reorderedTodos).toHaveLength(3)
-    expect(reorderedTodos[0].id).toBe('2')
-    expect(reorderedTodos[1].id).toBe('3')
-    expect(reorderedTodos[2].id).toBe('1')
+    expect(reorderedTodos).toHaveLength(3);
+    expect(reorderedTodos[0].id).toBe("2");
+    expect(reorderedTodos[1].id).toBe("3");
+    expect(reorderedTodos[2].id).toBe("1");
 
     // orderフィールドの値が正しく更新されることを確認
-    expect(reorderedTodos[0].order).toBe(0)
-    expect(reorderedTodos[1].order).toBe(1)
-    expect(reorderedTodos[2].order).toBe(2)
-  })
+    expect(reorderedTodos[0].order).toBe(0);
+    expect(reorderedTodos[1].order).toBe(1);
+    expect(reorderedTodos[2].order).toBe(2);
+  });
 
   // 概要: 無効なドロップ操作のハンドリングをテスト
   // 目的: over要素がnullの場合やアイテムが見つからない場合に適切に処理されることを保証
-  it('handles invalid drop operations gracefully', () => {
-    let reorderedTodos: Todo[] = []
+  it("handles invalid drop operations gracefully", () => {
+    let reorderedTodos: Todo[] = [];
     const onReorder = (todos: Todo[]) => {
-      reorderedTodos = todos
-    }
+      reorderedTodos = todos;
+    };
 
-    const { result } = renderHook(() => useTodoSorting(mockTodos, onReorder))
+    const { result } = renderHook(() => useTodoSorting(mockTodos, onReorder));
 
     act(() => {
       // Invalid drop (no over element) - simplified event object
       const dragEndEvent = {
-        active: { id: '1' },
+        active: { id: "1" },
         over: null,
-      } as DragEndEvent
-      result.current.handleDragEnd(dragEndEvent)
-    })
+      } as DragEndEvent;
+      result.current.handleDragEnd(dragEndEvent);
+    });
 
     // リストが変更されないことを確認
-    expect(reorderedTodos).toHaveLength(0)
-  })
+    expect(reorderedTodos).toHaveLength(0);
+  });
 
   // 概要: 並び順リセット機能をテスト
   // 目的: リセット機能が作成日時順にソートし、orderフィールドを正しく更新することを保証
-  it('resets order to creation date order', () => {
-    let reorderedTodos: Todo[] = []
+  it("resets order to creation date order", () => {
+    let reorderedTodos: Todo[] = [];
     const onReorder = (todos: Todo[]) => {
-      reorderedTodos = todos
-    }
+      reorderedTodos = todos;
+    };
 
-    const { result } = renderHook(() => useTodoSorting(mockTodos, onReorder))
+    const { result } = renderHook(() => useTodoSorting(mockTodos, onReorder));
 
     act(() => {
-      result.current.resetOrder()
-    })
+      result.current.resetOrder();
+    });
 
     // 作成日時順にソートされることを確認
-    expect(reorderedTodos).toHaveLength(3)
+    expect(reorderedTodos).toHaveLength(3);
     expect(reorderedTodos[0].createdAt.getTime()).toBeLessThan(
-      reorderedTodos[1].createdAt.getTime()
-    )
+      reorderedTodos[1].createdAt.getTime(),
+    );
     expect(reorderedTodos[1].createdAt.getTime()).toBeLessThan(
-      reorderedTodos[2].createdAt.getTime()
-    )
+      reorderedTodos[2].createdAt.getTime(),
+    );
 
     // orderフィールドが連続した値で更新されることを確認
-    expect(reorderedTodos[0].order).toBe(0)
-    expect(reorderedTodos[1].order).toBe(1)
-    expect(reorderedTodos[2].order).toBe(2)
-  })
+    expect(reorderedTodos[0].order).toBe(0);
+    expect(reorderedTodos[1].order).toBe(1);
+    expect(reorderedTodos[2].order).toBe(2);
+  });
 
   // 概要: 異なるソート基準での並び替え機能をテスト
   // 目的: アルファベット順、カテゴリ順などの様々なソート機能が正しく動作することを保証
-  it('sorts by different criteria', () => {
-    let reorderedTodos: Todo[] = []
+  it("sorts by different criteria", () => {
+    let reorderedTodos: Todo[] = [];
     const onReorder = (todos: Todo[]) => {
-      reorderedTodos = todos
-    }
+      reorderedTodos = todos;
+    };
 
-    const { result } = renderHook(() => useTodoSorting(mockTodos, onReorder))
+    const { result } = renderHook(() => useTodoSorting(mockTodos, onReorder));
 
     // アルファベット順でソート
     act(() => {
-      result.current.sortBy('alphabetical')
-    })
+      result.current.sortBy("alphabetical");
+    });
 
-    expect(reorderedTodos[0].text).toBe('First todo')
-    expect(reorderedTodos[1].text).toBe('Second todo')
-    expect(reorderedTodos[2].text).toBe('Third todo')
-  })
-})
+    expect(reorderedTodos[0].text).toBe("First todo");
+    expect(reorderedTodos[1].text).toBe("Second todo");
+    expect(reorderedTodos[2].text).toBe("Third todo");
+  });
+});

--- a/frontend/__tests__/setup/setup.ts
+++ b/frontend/__tests__/setup/setup.ts
@@ -1,8 +1,8 @@
-import '@testing-library/jest-dom'
-import '@testing-library/jest-dom/vitest'
+import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/vitest";
 
 // matchMediaのモック - ダークモード機能のテストに必要
-Object.defineProperty(window, 'matchMedia', {
+Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: (query: string) => ({
     matches: false,
@@ -14,4 +14,4 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: () => {},
     dispatchEvent: () => {},
   }),
-})
+});

--- a/frontend/__tests__/types/category.test.ts
+++ b/frontend/__tests__/types/category.test.ts
@@ -1,68 +1,68 @@
-import { describe, it, expect } from 'vitest'
-import type { Category } from '../../src/types/category'
+import { describe, it, expect } from "vitest";
+import type { Category } from "../../src/types/category";
 
-describe('Category型', () => {
+describe("Category型", () => {
   // 概要: Category型のオブジェクト作成のテスト
   // 目的: Categoryインターフェースに準拠したオブジェクトが作成できることを確認
-  it('正しいCategory型のオブジェクトを作成できる', () => {
+  it("正しいCategory型のオブジェクトを作成できる", () => {
     const category: Category = {
-      id: 'cat-1',
-      name: '仕事',
-      color: '#1976d2',
-    }
+      id: "cat-1",
+      name: "仕事",
+      color: "#1976d2",
+    };
 
-    expect(category.id).toBe('cat-1')
-    expect(category.name).toBe('仕事')
-    expect(category.color).toBe('#1976d2')
-  })
+    expect(category.id).toBe("cat-1");
+    expect(category.name).toBe("仕事");
+    expect(category.color).toBe("#1976d2");
+  });
 
   // 概要: Category型の必須プロパティのテスト
   // 目的: Category型に必要なすべてのプロパティが含まれていることを確認
-  it('必要なプロパティがすべて含まれている', () => {
+  it("必要なプロパティがすべて含まれている", () => {
     const category: Category = {
-      id: 'cat-2',
-      name: 'プライベート',
-      color: '#ff5722',
-    }
+      id: "cat-2",
+      name: "プライベート",
+      color: "#ff5722",
+    };
 
-    expect(category).toHaveProperty('id')
-    expect(category).toHaveProperty('name')
-    expect(category).toHaveProperty('color')
-  })
+    expect(category).toHaveProperty("id");
+    expect(category).toHaveProperty("name");
+    expect(category).toHaveProperty("color");
+  });
 
   // 概要: idプロパティの型チェック
   // 目的: idフィールドが文字列型であることを確認
-  it('idが文字列型である', () => {
+  it("idが文字列型である", () => {
     const category: Category = {
-      id: 'test-id',
-      name: 'テスト',
-      color: '#00ff00',
-    }
+      id: "test-id",
+      name: "テスト",
+      color: "#00ff00",
+    };
 
-    expect(typeof category.id).toBe('string')
-  })
+    expect(typeof category.id).toBe("string");
+  });
 
   // 概要: nameプロパティの型チェック
   // 目的: nameフィールドが文字列型であることを確認
-  it('nameが文字列型である', () => {
+  it("nameが文字列型である", () => {
     const category: Category = {
-      id: 'test-id',
-      name: 'テストカテゴリ',
-      color: '#ff0000',
-    }
+      id: "test-id",
+      name: "テストカテゴリ",
+      color: "#ff0000",
+    };
 
-    expect(typeof category.name).toBe('string')
-  })
+    expect(typeof category.name).toBe("string");
+  });
 
   // 概要: colorプロパティの型チェック
   // 目的: colorフィールドが文字列型であることを確認
-  it('colorが文字列型である', () => {
+  it("colorが文字列型である", () => {
     const category: Category = {
-      id: 'test-id',
-      name: 'テスト',
-      color: '#0000ff',
-    }
+      id: "test-id",
+      name: "テスト",
+      color: "#0000ff",
+    };
 
-    expect(typeof category.color).toBe('string')
-  })
-})
+    expect(typeof category.color).toBe("string");
+  });
+});

--- a/frontend/__tests__/types/editTodoData.test.ts
+++ b/frontend/__tests__/types/editTodoData.test.ts
@@ -1,78 +1,78 @@
-import { describe, it, expect } from 'vitest'
-import type { EditTodoData } from '../../src/types/todo'
+import { describe, it, expect } from "vitest";
+import type { EditTodoData } from "../../src/types/todo";
 
-describe('EditTodoData type', () => {
+describe("EditTodoData type", () => {
   // 概要: EditTodoDataインターフェースの基本構造をテスト
   // 目的: 型定義が期待通りのフィールドを持つことを保証
-  it('has correct structure with required text field', () => {
+  it("has correct structure with required text field", () => {
     const editData: EditTodoData = {
-      text: 'Test text',
-      tags: ['tag1', 'tag2'],
-    }
+      text: "Test text",
+      tags: ["tag1", "tag2"],
+    };
 
-    expect(editData.text).toBe('Test text')
-    expect(editData.tags).toEqual(['tag1', 'tag2'])
-    expect(editData.categoryId).toBeUndefined()
-  })
+    expect(editData.text).toBe("Test text");
+    expect(editData.tags).toEqual(["tag1", "tag2"]);
+    expect(editData.categoryId).toBeUndefined();
+  });
 
   // 概要: categoryIdがオプショナルであることをテスト
   // 目的: categoryIdフィールドが省略可能であることを保証
-  it('allows optional categoryId field', () => {
+  it("allows optional categoryId field", () => {
     const editDataWithCategory: EditTodoData = {
-      text: 'Test text',
-      categoryId: 'cat1',
+      text: "Test text",
+      categoryId: "cat1",
       tags: [],
-    }
+    };
 
     const editDataWithoutCategory: EditTodoData = {
-      text: 'Test text',
+      text: "Test text",
       tags: [],
-    }
+    };
 
-    expect(editDataWithCategory.categoryId).toBe('cat1')
-    expect(editDataWithoutCategory.categoryId).toBeUndefined()
-  })
+    expect(editDataWithCategory.categoryId).toBe("cat1");
+    expect(editDataWithoutCategory.categoryId).toBeUndefined();
+  });
 
   // 概要: tagsフィールドが配列であることをテスト
   // 目的: tagsフィールドが適切な型（string[]）であることを保証
-  it('enforces tags as string array', () => {
+  it("enforces tags as string array", () => {
     const editData: EditTodoData = {
-      text: 'Test text',
+      text: "Test text",
       tags: [],
-    }
+    };
 
-    editData.tags.push('new tag')
-    expect(editData.tags).toContain('new tag')
-    expect(Array.isArray(editData.tags)).toBe(true)
-  })
+    editData.tags.push("new tag");
+    expect(editData.tags).toContain("new tag");
+    expect(Array.isArray(editData.tags)).toBe(true);
+  });
 
   // 概要: textフィールドが必須であることをテスト
   // 目的: textフィールドが省略できないことを保証
-  it('requires text field', () => {
+  it("requires text field", () => {
     // TypeScriptコンパイル時エラーになることを期待
     // 以下のコードはコンパイルエラーになるべき：
     // const invalidEditData: EditTodoData = { tags: [] }
 
     const validEditData: EditTodoData = {
-      text: '',
+      text: "",
       tags: [],
-    }
+    };
 
-    expect(validEditData.text).toBeDefined()
-    expect(typeof validEditData.text).toBe('string')
-  })
+    expect(validEditData.text).toBeDefined();
+    expect(typeof validEditData.text).toBe("string");
+  });
 
   // 概要: 完全なEditTodoDataオブジェクトの作成テスト
   // 目的: 全てのフィールドを含むオブジェクトが正しく作成できることを保証
-  it('creates complete EditTodoData object', () => {
+  it("creates complete EditTodoData object", () => {
     const completeEditData: EditTodoData = {
-      text: 'Complete task description',
-      categoryId: 'work',
-      tags: ['urgent', 'important', 'today'],
-    }
+      text: "Complete task description",
+      categoryId: "work",
+      tags: ["urgent", "important", "today"],
+    };
 
-    expect(completeEditData.text).toBe('Complete task description')
-    expect(completeEditData.categoryId).toBe('work')
-    expect(completeEditData.tags).toEqual(['urgent', 'important', 'today'])
-  })
-})
+    expect(completeEditData.text).toBe("Complete task description");
+    expect(completeEditData.categoryId).toBe("work");
+    expect(completeEditData.tags).toEqual(["urgent", "important", "today"]);
+  });
+});

--- a/frontend/__tests__/types/todo.test.ts
+++ b/frontend/__tests__/types/todo.test.ts
@@ -1,123 +1,123 @@
-import { describe, it, expect } from 'vitest'
-import type { Todo } from '../../src/types/todo'
+import { describe, it, expect } from "vitest";
+import type { Todo } from "../../src/types/todo";
 
-describe('拡張されたTodo型', () => {
+describe("拡張されたTodo型", () => {
   // 概要: 拡張されたTodo型の基本プロパティのテスト
   // 目的: 新しいTodo型が従来の必須プロパティをすべて含んでいることを確認
-  it('従来のTodoプロパティを含む', () => {
+  it("従来のTodoプロパティを含む", () => {
     const todo: Todo = {
-      id: 'todo-1',
-      text: 'テストタスク',
+      id: "todo-1",
+      text: "テストタスク",
       completed: false,
       createdAt: new Date(),
       categoryId: undefined,
       tags: [],
-    }
+    };
 
-    expect(todo).toHaveProperty('id')
-    expect(todo).toHaveProperty('text')
-    expect(todo).toHaveProperty('completed')
-    expect(todo).toHaveProperty('createdAt')
-  })
+    expect(todo).toHaveProperty("id");
+    expect(todo).toHaveProperty("text");
+    expect(todo).toHaveProperty("completed");
+    expect(todo).toHaveProperty("createdAt");
+  });
 
   // 概要: categoryIdプロパティのオプショナル性のテスト
   // 目的: categoryIdがオプショナルであり、ありとなしの両方で正しく動作することを確認
-  it('categoryIdプロパティを含む（オプショナル）', () => {
+  it("categoryIdプロパティを含む（オプショナル）", () => {
     const todoWithCategory: Todo = {
-      id: 'todo-1',
-      text: 'カテゴリ付きタスク',
+      id: "todo-1",
+      text: "カテゴリ付きタスク",
       completed: false,
       createdAt: new Date(),
-      categoryId: 'cat-1',
+      categoryId: "cat-1",
       tags: [],
-    }
+    };
 
     const todoWithoutCategory: Todo = {
-      id: 'todo-2',
-      text: 'カテゴリなしタスク',
+      id: "todo-2",
+      text: "カテゴリなしタスク",
       completed: false,
       createdAt: new Date(),
       categoryId: undefined,
       tags: [],
-    }
+    };
 
-    expect(todoWithCategory.categoryId).toBe('cat-1')
-    expect(todoWithoutCategory.categoryId).toBeUndefined()
-  })
+    expect(todoWithCategory.categoryId).toBe("cat-1");
+    expect(todoWithoutCategory.categoryId).toBeUndefined();
+  });
 
   // 概要: tagsプロパティの型と動作のテスト
   // 目的: tagsが文字列配列であり、設定したタグが正しく保持されることを確認
-  it('tagsプロパティを含む（文字列配列）', () => {
+  it("tagsプロパティを含む（文字列配列）", () => {
     const todo: Todo = {
-      id: 'todo-1',
-      text: 'タグ付きタスク',
+      id: "todo-1",
+      text: "タグ付きタスク",
       completed: false,
       createdAt: new Date(),
       categoryId: undefined,
-      tags: ['重要', '急ぎ'],
-    }
+      tags: ["重要", "急ぎ"],
+    };
 
-    expect(Array.isArray(todo.tags)).toBe(true)
-    expect(todo.tags).toHaveLength(2)
-    expect(todo.tags).toContain('重要')
-    expect(todo.tags).toContain('急ぎ')
-  })
+    expect(Array.isArray(todo.tags)).toBe(true);
+    expect(todo.tags).toHaveLength(2);
+    expect(todo.tags).toContain("重要");
+    expect(todo.tags).toContain("急ぎ");
+  });
 
   // 概要: tagsプロパティの空配列対応のテスト
   // 目的: tagsが空配列でも正しく動作することを確認
-  it('tagsプロパティは空配列でも有効', () => {
+  it("tagsプロパティは空配列でも有効", () => {
     const todo: Todo = {
-      id: 'todo-1',
-      text: 'タグなしタスク',
+      id: "todo-1",
+      text: "タグなしタスク",
       completed: false,
       createdAt: new Date(),
       categoryId: undefined,
       tags: [],
-    }
+    };
 
-    expect(Array.isArray(todo.tags)).toBe(true)
-    expect(todo.tags).toHaveLength(0)
-  })
+    expect(Array.isArray(todo.tags)).toBe(true);
+    expect(todo.tags).toHaveLength(0);
+  });
 
   // 概要: カテゴリとタグの組み合わせのテスト
   // 目的: categoryIdとtagsの両方を持つTodoが正しく作成できることを確認
-  it('カテゴリIDとタグの両方を持つTodoが作成できる', () => {
+  it("カテゴリIDとタグの両方を持つTodoが作成できる", () => {
     const todo: Todo = {
-      id: 'todo-1',
-      text: '完全なタスク',
+      id: "todo-1",
+      text: "完全なタスク",
       completed: true,
       createdAt: new Date(),
-      categoryId: 'work-category',
-      tags: ['重要', '今日中', 'レビュー'],
-    }
+      categoryId: "work-category",
+      tags: ["重要", "今日中", "レビュー"],
+    };
 
-    expect(todo.categoryId).toBe('work-category')
-    expect(todo.tags).toHaveLength(3)
-    expect(todo.tags).toEqual(['重要', '今日中', 'レビュー'])
-  })
+    expect(todo.categoryId).toBe("work-category");
+    expect(todo.tags).toHaveLength(3);
+    expect(todo.tags).toEqual(["重要", "今日中", "レビュー"]);
+  });
 
   // 概要: 拡張されたTodo型の後方互換性のテスト
   // 目的: 新しいプロパティを追加しても従来のTodoと互換性が保たれることを確認
-  it('従来のTodoとの後方互換性を保つ', () => {
+  it("従来のTodoとの後方互換性を保つ", () => {
     // categoryIdとtagsなしでも作成可能であることを確認
     const basicTodo = {
-      id: 'todo-1',
-      text: '基本タスク',
+      id: "todo-1",
+      text: "基本タスク",
       completed: false,
       createdAt: new Date(),
-    }
+    };
 
     // 型チェックのため、拡張プロパティを追加
     const extendedTodo: Todo = {
       ...basicTodo,
       categoryId: undefined,
       tags: [],
-    }
+    };
 
-    expect(extendedTodo.id).toBe('todo-1')
-    expect(extendedTodo.text).toBe('基本タスク')
-    expect(extendedTodo.completed).toBe(false)
-    expect(extendedTodo.categoryId).toBeUndefined()
-    expect(extendedTodo.tags).toEqual([])
-  })
-})
+    expect(extendedTodo.id).toBe("todo-1");
+    expect(extendedTodo.text).toBe("基本タスク");
+    expect(extendedTodo.completed).toBe(false);
+    expect(extendedTodo.categoryId).toBeUndefined();
+    expect(extendedTodo.tags).toEqual([]);
+  });
+});

--- a/frontend/__tests__/utils/filterLogic.test.ts
+++ b/frontend/__tests__/utils/filterLogic.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
-import type { Todo } from '../../src/types/todo'
-import type { FilterState } from '../../src/types/filter'
+import { describe, it, expect } from "vitest";
+import type { Todo } from "../../src/types/todo";
+import type { FilterState } from "../../src/types/filter";
 import {
   filterByCompletion,
   filterByCategories,
@@ -8,303 +8,305 @@ import {
   filterBySearch,
   applyFilters,
   getActiveFilterCount,
-} from '../../src/utils/filterLogic'
+} from "../../src/utils/filterLogic";
 
 const mockTodos: Todo[] = [
   {
-    id: '1',
-    text: 'Buy groceries',
+    id: "1",
+    text: "Buy groceries",
     completed: false,
-    createdAt: new Date('2025-01-01'),
-    categoryId: 'personal',
-    tags: ['shopping', 'urgent'],
+    createdAt: new Date("2025-01-01"),
+    categoryId: "personal",
+    tags: ["shopping", "urgent"],
   },
   {
-    id: '2',
-    text: 'Fix bug in APPLICATION',
+    id: "2",
+    text: "Fix bug in APPLICATION",
     completed: true,
-    createdAt: new Date('2025-01-02'),
-    categoryId: 'work',
-    tags: ['development', 'urgent'],
+    createdAt: new Date("2025-01-02"),
+    categoryId: "work",
+    tags: ["development", "urgent"],
   },
   {
-    id: '3',
-    text: 'Read book',
+    id: "3",
+    text: "Read book",
     completed: false,
-    createdAt: new Date('2025-01-03'),
-    categoryId: 'personal',
-    tags: ['learning'],
+    createdAt: new Date("2025-01-03"),
+    categoryId: "personal",
+    tags: ["learning"],
   },
   {
-    id: '4',
-    text: 'Team meeting preparation',
+    id: "4",
+    text: "Team meeting preparation",
     completed: true,
-    createdAt: new Date('2025-01-04'),
-    categoryId: 'work',
-    tags: ['meeting', 'preparation'],
+    createdAt: new Date("2025-01-04"),
+    categoryId: "work",
+    tags: ["meeting", "preparation"],
   },
   {
-    id: '5',
-    text: 'No category todo',
+    id: "5",
+    text: "No category todo",
     completed: false,
-    createdAt: new Date('2025-01-05'),
+    createdAt: new Date("2025-01-05"),
     categoryId: undefined,
     tags: [],
   },
-]
+];
 
-describe('filterLogic', () => {
-  describe('filterByCompletion', () => {
+describe("filterLogic", () => {
+  describe("filterByCompletion", () => {
     // 概要: 全ての状態で全Todoが返されることを確認
     // 目的: 'all'指定時にフィルタリングが行われないことを保証
     it('returns all todos when status is "all"', () => {
-      const result = filterByCompletion(mockTodos, 'all')
-      expect(result).toEqual(mockTodos)
-    })
+      const result = filterByCompletion(mockTodos, "all");
+      expect(result).toEqual(mockTodos);
+    });
 
     // 概要: 完了済みTodoのみが返されることを確認
     // 目的: 'completed'指定時に完了済みTodoのみが正しくフィルタリングされることを保証
     it('returns only completed todos when status is "completed"', () => {
-      const result = filterByCompletion(mockTodos, 'completed')
-      expect(result).toHaveLength(2)
-      expect(result.every(todo => todo.completed)).toBe(true)
-    })
+      const result = filterByCompletion(mockTodos, "completed");
+      expect(result).toHaveLength(2);
+      expect(result.every((todo) => todo.completed)).toBe(true);
+    });
 
     // 概要: 未完了Todoのみが返されることを確認
     // 目的: 'incomplete'指定時に未完了Todoのみが正しくフィルタリングされることを保証
     it('returns only incomplete todos when status is "incomplete"', () => {
-      const result = filterByCompletion(mockTodos, 'incomplete')
-      expect(result).toHaveLength(3)
-      expect(result.every(todo => !todo.completed)).toBe(true)
-    })
+      const result = filterByCompletion(mockTodos, "incomplete");
+      expect(result).toHaveLength(3);
+      expect(result.every((todo) => !todo.completed)).toBe(true);
+    });
 
     // 概要: 空配列に対する処理の確認
     // 目的: エッジケースでもエラーが発生しないことを保証
-    it('handles empty array', () => {
-      const result = filterByCompletion([], 'completed')
-      expect(result).toEqual([])
-    })
-  })
+    it("handles empty array", () => {
+      const result = filterByCompletion([], "completed");
+      expect(result).toEqual([]);
+    });
+  });
 
-  describe('filterByCategories', () => {
+  describe("filterByCategories", () => {
     // 概要: 空のカテゴリIDリストで全Todoが返されることを確認
     // 目的: カテゴリフィルターが無効時に全Todoが表示されることを保証
-    it('returns all todos when category ids is empty', () => {
-      const result = filterByCategories(mockTodos, [])
-      expect(result).toEqual(mockTodos)
-    })
+    it("returns all todos when category ids is empty", () => {
+      const result = filterByCategories(mockTodos, []);
+      expect(result).toEqual(mockTodos);
+    });
 
     // 概要: 指定カテゴリのTodoのみが返されることを確認
     // 目的: 単一カテゴリでのフィルタリングが正しく動作することを保証
-    it('returns todos with specified category', () => {
-      const result = filterByCategories(mockTodos, ['work'])
-      expect(result).toHaveLength(2)
-      expect(result.every(todo => todo.categoryId === 'work')).toBe(true)
-    })
+    it("returns todos with specified category", () => {
+      const result = filterByCategories(mockTodos, ["work"]);
+      expect(result).toHaveLength(2);
+      expect(result.every((todo) => todo.categoryId === "work")).toBe(true);
+    });
 
     // 概要: 複数カテゴリでのフィルタリング確認
     // 目的: 複数カテゴリ指定時にOR条件でフィルタリングされることを保証
-    it('returns todos with any of specified categories', () => {
-      const result = filterByCategories(mockTodos, ['work', 'personal'])
-      expect(result).toHaveLength(4)
+    it("returns todos with any of specified categories", () => {
+      const result = filterByCategories(mockTodos, ["work", "personal"]);
+      expect(result).toHaveLength(4);
       expect(
-        result.every(todo =>
-          ['work', 'personal'].includes(todo.categoryId || '')
-        )
-      ).toBe(true)
-    })
+        result.every((todo) =>
+          ["work", "personal"].includes(todo.categoryId || ""),
+        ),
+      ).toBe(true);
+    });
 
     // 概要: カテゴリ未設定Todoの処理確認
     // 目的: categoryIdがundefinedのTodoが適切に処理されることを保証
-    it('excludes todos without category when filtering by category', () => {
-      const result = filterByCategories(mockTodos, ['personal'])
-      expect(result).toHaveLength(2)
-      expect(result.find(todo => todo.id === '5')).toBeUndefined()
-    })
-  })
+    it("excludes todos without category when filtering by category", () => {
+      const result = filterByCategories(mockTodos, ["personal"]);
+      expect(result).toHaveLength(2);
+      expect(result.find((todo) => todo.id === "5")).toBeUndefined();
+    });
+  });
 
-  describe('filterByTags', () => {
+  describe("filterByTags", () => {
     // 概要: 空のタグリストで全Todoが返されることを確認
     // 目的: タグフィルターが無効時に全Todoが表示されることを保証
-    it('returns all todos when tags is empty', () => {
-      const result = filterByTags(mockTodos, [], 'any')
-      expect(result).toEqual(mockTodos)
-    })
+    it("returns all todos when tags is empty", () => {
+      const result = filterByTags(mockTodos, [], "any");
+      expect(result).toEqual(mockTodos);
+    });
 
     // 概要: OR条件でのタグフィルタリング確認
     // 目的: 'any'指定時に指定タグのいずれかを持つTodoが返されることを保証
-    it('returns todos with any of specified tags (OR condition)', () => {
-      const result = filterByTags(mockTodos, ['urgent'], 'any')
-      expect(result).toHaveLength(2)
-      expect(result.every(todo => todo.tags.includes('urgent'))).toBe(true)
-    })
+    it("returns todos with any of specified tags (OR condition)", () => {
+      const result = filterByTags(mockTodos, ["urgent"], "any");
+      expect(result).toHaveLength(2);
+      expect(result.every((todo) => todo.tags.includes("urgent"))).toBe(true);
+    });
 
     // 概要: AND条件でのタグフィルタリング確認
     // 目的: 'all'指定時に指定タグを全て持つTodoが返されることを保証
-    it('returns todos with all specified tags (AND condition)', () => {
-      const result = filterByTags(mockTodos, ['urgent', 'shopping'], 'all')
-      expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('1')
-    })
+    it("returns todos with all specified tags (AND condition)", () => {
+      const result = filterByTags(mockTodos, ["urgent", "shopping"], "all");
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("1");
+    });
 
     // 概要: AND条件で該当なしの場合の確認
     // 目的: 全てのタグを持つTodoがない場合に空配列が返されることを保証
-    it('returns empty array when no todos have all specified tags', () => {
-      const result = filterByTags(mockTodos, ['urgent', 'nonexistent'], 'all')
-      expect(result).toHaveLength(0)
-    })
+    it("returns empty array when no todos have all specified tags", () => {
+      const result = filterByTags(mockTodos, ["urgent", "nonexistent"], "all");
+      expect(result).toHaveLength(0);
+    });
 
     // 概要: タグなしTodoの処理確認
     // 目的: tagsが空配列のTodoが適切に処理されることを保証
-    it('excludes todos without tags when filtering by tags', () => {
-      const result = filterByTags(mockTodos, ['learning'], 'any')
-      expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('3')
-    })
-  })
+    it("excludes todos without tags when filtering by tags", () => {
+      const result = filterByTags(mockTodos, ["learning"], "any");
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("3");
+    });
+  });
 
-  describe('filterBySearch', () => {
+  describe("filterBySearch", () => {
     // 概要: 空の検索文字列で全Todoが返されることを確認
     // 目的: 検索フィルターが無効時に全Todoが表示されることを保証
-    it('returns all todos when search text is empty', () => {
-      const result = filterBySearch(mockTodos, '')
-      expect(result).toEqual(mockTodos)
-    })
+    it("returns all todos when search text is empty", () => {
+      const result = filterBySearch(mockTodos, "");
+      expect(result).toEqual(mockTodos);
+    });
 
     // 概要: 大文字小文字を区別しない検索の確認
     // 目的: 検索が大文字小文字を区別せずに動作することを保証
-    it('performs case-insensitive search', () => {
-      const result = filterBySearch(mockTodos, 'APPLICATION')
-      expect(result).toHaveLength(1)
-      expect(result[0].text).toContain('APPLICATION')
-    })
+    it("performs case-insensitive search", () => {
+      const result = filterBySearch(mockTodos, "APPLICATION");
+      expect(result).toHaveLength(1);
+      expect(result[0].text).toContain("APPLICATION");
+    });
 
     // 概要: 部分一致検索の確認
     // 目的: 部分文字列での検索が正しく動作することを保証
-    it('performs partial text search', () => {
-      const result = filterBySearch(mockTodos, 'bug')
-      expect(result).toHaveLength(1)
-      expect(result[0].text).toContain('bug')
-    })
+    it("performs partial text search", () => {
+      const result = filterBySearch(mockTodos, "bug");
+      expect(result).toHaveLength(1);
+      expect(result[0].text).toContain("bug");
+    });
 
     // 概要: 該当なし検索の確認
     // 目的: 検索文字列に該当するTodoがない場合に空配列が返されることを保証
-    it('returns empty array when no todos match search text', () => {
-      const result = filterBySearch(mockTodos, 'nonexistent')
-      expect(result).toHaveLength(0)
-    })
+    it("returns empty array when no todos match search text", () => {
+      const result = filterBySearch(mockTodos, "nonexistent");
+      expect(result).toHaveLength(0);
+    });
 
     // 概要: 空白文字の処理確認
     // 目的: 空白のみの検索文字列が適切に処理されることを保証
-    it('treats whitespace-only search as empty', () => {
-      const result = filterBySearch(mockTodos, '   ')
-      expect(result).toEqual(mockTodos)
-    })
-  })
+    it("treats whitespace-only search as empty", () => {
+      const result = filterBySearch(mockTodos, "   ");
+      expect(result).toEqual(mockTodos);
+    });
+  });
 
-  describe('applyFilters', () => {
+  describe("applyFilters", () => {
     // 概要: デフォルトフィルターで全Todoが返されることを確認
     // 目的: 初期状態で全Todoが表示されることを保証
-    it('returns all todos with default filters', () => {
+    it("returns all todos with default filters", () => {
       const filters: FilterState = {
-        completionStatus: 'all',
+        completionStatus: "all",
         categoryIds: [],
         tags: [],
-        tagCondition: 'any',
-        searchText: '',
-      }
-      const result = applyFilters(mockTodos, filters)
-      expect(result).toEqual(mockTodos)
-    })
+        tagCondition: "any",
+        searchText: "",
+      };
+      const result = applyFilters(mockTodos, filters);
+      expect(result).toEqual(mockTodos);
+    });
 
     // 概要: 複数フィルターの組み合わせ確認
     // 目的: 複数の条件を同時に適用したフィルタリングが正しく動作することを保証
-    it('applies multiple filters correctly', () => {
+    it("applies multiple filters correctly", () => {
       const filters: FilterState = {
-        completionStatus: 'incomplete',
-        categoryIds: ['personal'],
+        completionStatus: "incomplete",
+        categoryIds: ["personal"],
         tags: [],
-        tagCondition: 'any',
-        searchText: '',
-      }
-      const result = applyFilters(mockTodos, filters)
-      expect(result).toHaveLength(2)
+        tagCondition: "any",
+        searchText: "",
+      };
+      const result = applyFilters(mockTodos, filters);
+      expect(result).toHaveLength(2);
       expect(
-        result.every(todo => !todo.completed && todo.categoryId === 'personal')
-      ).toBe(true)
-    })
+        result.every(
+          (todo) => !todo.completed && todo.categoryId === "personal",
+        ),
+      ).toBe(true);
+    });
 
     // 概要: 全フィルター条件の組み合わせ確認
     // 目的: 全ての種類のフィルターを同時適用した場合の動作を保証
-    it('applies all filter types together', () => {
+    it("applies all filter types together", () => {
       const filters: FilterState = {
-        completionStatus: 'incomplete',
-        categoryIds: ['personal'],
-        tags: ['shopping'],
-        tagCondition: 'any',
-        searchText: 'Buy',
-      }
-      const result = applyFilters(mockTodos, filters)
-      expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('1')
-    })
-  })
+        completionStatus: "incomplete",
+        categoryIds: ["personal"],
+        tags: ["shopping"],
+        tagCondition: "any",
+        searchText: "Buy",
+      };
+      const result = applyFilters(mockTodos, filters);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("1");
+    });
+  });
 
-  describe('getActiveFilterCount', () => {
+  describe("getActiveFilterCount", () => {
     // 概要: デフォルトフィルターでのカウント確認
     // 目的: 初期状態でアクティブフィルター数が0であることを保証
-    it('returns 0 for default filters', () => {
+    it("returns 0 for default filters", () => {
       const filters: FilterState = {
-        completionStatus: 'all',
+        completionStatus: "all",
         categoryIds: [],
         tags: [],
-        tagCondition: 'any',
-        searchText: '',
-      }
-      const count = getActiveFilterCount(filters)
-      expect(count).toBe(0)
-    })
+        tagCondition: "any",
+        searchText: "",
+      };
+      const count = getActiveFilterCount(filters);
+      expect(count).toBe(0);
+    });
 
     // 概要: 単一フィルターのカウント確認
     // 目的: 1つのフィルターが設定された時のカウントが正しいことを保証
-    it('counts completion status filter', () => {
+    it("counts completion status filter", () => {
       const filters: FilterState = {
-        completionStatus: 'completed',
+        completionStatus: "completed",
         categoryIds: [],
         tags: [],
-        tagCondition: 'any',
-        searchText: '',
-      }
-      const count = getActiveFilterCount(filters)
-      expect(count).toBe(1)
-    })
+        tagCondition: "any",
+        searchText: "",
+      };
+      const count = getActiveFilterCount(filters);
+      expect(count).toBe(1);
+    });
 
     // 概要: 複数フィルターのカウント確認
     // 目的: 複数のフィルターが設定された時のカウントが正しいことを保証
-    it('counts multiple active filters', () => {
+    it("counts multiple active filters", () => {
       const filters: FilterState = {
-        completionStatus: 'completed',
-        categoryIds: ['work', 'personal'],
-        tags: ['urgent'],
-        tagCondition: 'any',
-        searchText: 'test',
-      }
-      const count = getActiveFilterCount(filters)
-      expect(count).toBe(4)
-    })
+        completionStatus: "completed",
+        categoryIds: ["work", "personal"],
+        tags: ["urgent"],
+        tagCondition: "any",
+        searchText: "test",
+      };
+      const count = getActiveFilterCount(filters);
+      expect(count).toBe(4);
+    });
 
     // 概要: 空白検索文字列の処理確認
     // 目的: 空白のみの検索文字列がカウントされないことを保証
-    it('does not count whitespace-only search text', () => {
+    it("does not count whitespace-only search text", () => {
       const filters: FilterState = {
-        completionStatus: 'all',
+        completionStatus: "all",
         categoryIds: [],
         tags: [],
-        tagCondition: 'any',
-        searchText: '   ',
-      }
-      const count = getActiveFilterCount(filters)
-      expect(count).toBe(0)
-    })
-  })
-})
+        tagCondition: "any",
+        searchText: "   ",
+      };
+      const count = getActiveFilterCount(filters);
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,18 +1,18 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { globalIgnores } from "eslint/config";
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(["dist"]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
-      reactHooks.configs['recommended-latest'],
+      reactHooks.configs["recommended-latest"],
       reactRefresh.configs.vite,
     ],
     languageOptions: {
@@ -20,4 +20,4 @@ export default tseslint.config([
       globals: globals.browser,
     },
   },
-])
+]);

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,38 +1,38 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-  testDir: './__tests__/e2e',
+  testDir: "./__tests__/e2e",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: "html",
   use: {
-    baseURL: 'http://localhost:5173',
-    trace: 'on-first-retry',
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
   },
 
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
 
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
     },
 
     {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
   ],
 
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:5173',
+    command: "npm run dev",
+    url: "http://localhost:5173",
     reuseExistingServer: true,
     timeout: 120 * 1000,
   },
-})
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,31 +1,31 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route } from "react-router-dom";
 import {
   ThemeProvider,
   createTheme,
   CssBaseline,
   Container,
-} from '@mui/material'
-import { useMemo } from 'react'
-import { TodoApp } from './components/TodoApp'
-import { Navigation } from './components/Navigation'
-import { CategoriesPage } from './components/CategoriesPage'
-import { CategoryForm } from './components/CategoryForm'
-import { NotFoundPage } from './components/NotFoundPage'
-import { useDarkMode } from './hooks/useDarkMode'
-import './App.css'
+} from "@mui/material";
+import { useMemo } from "react";
+import { TodoApp } from "./components/TodoApp";
+import { Navigation } from "./components/Navigation";
+import { CategoriesPage } from "./components/CategoriesPage";
+import { CategoryForm } from "./components/CategoryForm";
+import { NotFoundPage } from "./components/NotFoundPage";
+import { useDarkMode } from "./hooks/useDarkMode";
+import "./App.css";
 
 function App() {
-  const { isDarkMode, toggleDarkMode } = useDarkMode()
+  const { isDarkMode, toggleDarkMode } = useDarkMode();
 
   const theme = useMemo(
     () =>
       createTheme({
         palette: {
-          mode: isDarkMode ? 'dark' : 'light',
+          mode: isDarkMode ? "dark" : "light",
         },
       }),
-    [isDarkMode]
-  )
+    [isDarkMode],
+  );
 
   return (
     <ThemeProvider theme={theme}>
@@ -35,13 +35,13 @@ function App() {
         <Container
           maxWidth="md"
           sx={{
-            minHeight: 'calc(100vh - 64px)', // AppBarの高さ(64px)を差し引いた最小高さ
+            minHeight: "calc(100vh - 64px)", // AppBarの高さ(64px)を差し引いた最小高さ
             py: 0, // パディングを統一
-            display: 'flex',
-            flexDirection: 'column',
-            width: '100%', // 明示的に幅を指定
-            maxWidth: '900px', // Material-UI md breakpoint
-            margin: '0 auto', // 中央配置を保証
+            display: "flex",
+            flexDirection: "column",
+            width: "100%", // 明示的に幅を指定
+            maxWidth: "900px", // Material-UI md breakpoint
+            margin: "0 auto", // 中央配置を保証
           }}
         >
           <Routes>
@@ -54,7 +54,7 @@ function App() {
         </Container>
       </div>
     </ThemeProvider>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/CategoriesPage.tsx
+++ b/frontend/src/components/CategoriesPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Paper,
   Box,
@@ -13,63 +13,63 @@ import {
   Stack,
   Snackbar,
   Alert,
-} from '@mui/material'
-import { Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material'
-import { useCategoryManagement } from '../hooks/useCategoryManagement'
+} from "@mui/material";
+import { Edit as EditIcon, Delete as DeleteIcon } from "@mui/icons-material";
+import { useCategoryManagement } from "../hooks/useCategoryManagement";
 
 export const CategoriesPage = () => {
-  const navigate = useNavigate()
-  const { categories, deleteCategory } = useCategoryManagement()
+  const navigate = useNavigate();
+  const { categories, deleteCategory } = useCategoryManagement();
   const [snackbar, setSnackbar] = useState<{
-    open: boolean
-    message: string
-    severity: 'success' | 'error'
+    open: boolean;
+    message: string;
+    severity: "success" | "error";
   }>({
     open: false,
-    message: '',
-    severity: 'success',
-  })
+    message: "",
+    severity: "success",
+  });
 
   const handleNewCategory = () => {
-    navigate('/categories/new')
-  }
+    navigate("/categories/new");
+  };
 
   const handleEditCategory = (id: string) => {
-    navigate(`/categories/${id}/edit`)
-  }
+    navigate(`/categories/${id}/edit`);
+  };
 
   const handleDeleteCategory = (id: string) => {
-    const confirmed = confirm('このカテゴリを削除しますか？')
-    if (!confirmed) return
+    const confirmed = confirm("このカテゴリを削除しますか？");
+    if (!confirmed) return;
 
-    const success = deleteCategory(id)
+    const success = deleteCategory(id);
     if (success) {
       setSnackbar({
         open: true,
-        message: 'カテゴリを削除しました',
-        severity: 'success',
-      })
+        message: "カテゴリを削除しました",
+        severity: "success",
+      });
     } else {
       setSnackbar({
         open: true,
-        message: '使用中のカテゴリは削除できません',
-        severity: 'error',
-      })
+        message: "使用中のカテゴリは削除できません",
+        severity: "error",
+      });
     }
-  }
+  };
 
   const handleCloseSnackbar = () => {
-    setSnackbar(prev => ({ ...prev, open: false }))
-  }
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  };
 
   const formatDate = (date: Date | string) => {
-    const dateObj = date instanceof Date ? date : new Date(date)
-    return new Intl.DateTimeFormat('ja-JP', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    }).format(dateObj)
-  }
+    const dateObj = date instanceof Date ? date : new Date(date);
+    return new Intl.DateTimeFormat("ja-JP", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(dateObj);
+  };
 
   return (
     <Box sx={{ flex: 1 }}>
@@ -103,7 +103,7 @@ export const CategoriesPage = () => {
           </Typography>
         ) : (
           <List>
-            {categories.map(category => (
+            {categories.map((category) => (
               <ListItem
                 key={category.id}
                 divider
@@ -136,11 +136,11 @@ export const CategoriesPage = () => {
                     size="small"
                     sx={{
                       backgroundColor: category.color,
-                      color: 'white',
+                      color: "white",
                       minWidth: 16,
                       height: 16,
-                      borderRadius: '50%',
-                      '& .MuiChip-label': {
+                      borderRadius: "50%",
+                      "& .MuiChip-label": {
                         padding: 0,
                       },
                     }}
@@ -153,7 +153,7 @@ export const CategoriesPage = () => {
                     <>
                       {category.description}
                       <br />
-                      作成日: {formatDate(category.createdAt)} | 更新日:{' '}
+                      作成日: {formatDate(category.createdAt)} | 更新日:{" "}
                       {formatDate(category.updatedAt)}
                     </>
                   }
@@ -168,12 +168,12 @@ export const CategoriesPage = () => {
         open={snackbar.open}
         autoHideDuration={6000}
         onClose={handleCloseSnackbar}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
       >
         <Alert onClose={handleCloseSnackbar} severity={snackbar.severity}>
           {snackbar.message}
         </Alert>
       </Snackbar>
     </Box>
-  )
-}
+  );
+};

--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import {
   Paper,
   Box,
@@ -8,25 +8,28 @@ import {
   Button,
   Stack,
   Alert,
-} from '@mui/material'
-import { useCategoryManagement } from '../hooks/useCategoryManagement'
-import type { CategoryFormData } from '../types/category'
+} from "@mui/material";
+import { useCategoryManagement } from "../hooks/useCategoryManagement";
+import type { CategoryFormData } from "../types/category";
 
 export const CategoryForm = () => {
-  const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
-  const { categories, createCategory, updateCategory } = useCategoryManagement()
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { categories, createCategory, updateCategory } =
+    useCategoryManagement();
 
-  const isEdit = Boolean(id)
-  const existingCategory = isEdit ? categories.find(cat => cat.id === id) : null
+  const isEdit = Boolean(id);
+  const existingCategory = isEdit
+    ? categories.find((cat) => cat.id === id)
+    : null;
 
   const [formData, setFormData] = useState<CategoryFormData>({
-    name: '',
-    color: '#1976d2',
-    description: '',
-  })
+    name: "",
+    color: "#1976d2",
+    description: "",
+  });
 
-  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [errors, setErrors] = useState<Record<string, string>>({});
 
   // 編集モード時の初期値設定
   useEffect(() => {
@@ -34,10 +37,10 @@ export const CategoryForm = () => {
       setFormData({
         name: existingCategory.name,
         color: existingCategory.color,
-        description: existingCategory.description || '',
-      })
+        description: existingCategory.description || "",
+      });
     }
-  }, [isEdit, existingCategory])
+  }, [isEdit, existingCategory]);
 
   // 編集モードで存在しないカテゴリの場合
   if (isEdit && !existingCategory) {
@@ -47,78 +50,78 @@ export const CategoryForm = () => {
           <Alert severity="error">カテゴリが見つかりません</Alert>
         </Paper>
       </Box>
-    )
+    );
   }
 
   const handleChange =
     (field: keyof CategoryFormData) =>
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setFormData(prev => ({
+      setFormData((prev) => ({
         ...prev,
         [field]: event.target.value,
-      }))
+      }));
 
       // エラーをクリア
       if (errors[field]) {
-        setErrors(prev => ({
+        setErrors((prev) => ({
           ...prev,
-          [field]: '',
-        }))
+          [field]: "",
+        }));
       }
-    }
+    };
 
   const validateForm = (): boolean => {
-    const newErrors: Record<string, string> = {}
+    const newErrors: Record<string, string> = {};
 
     // 必須チェック
     if (!formData.name.trim()) {
-      newErrors.name = 'カテゴリ名は必須です'
+      newErrors.name = "カテゴリ名は必須です";
     } else {
       // 重複チェック（編集時は自分以外をチェック）
       const isDuplicate = categories.some(
-        cat => cat.name === formData.name.trim() && cat.id !== id
-      )
+        (cat) => cat.name === formData.name.trim() && cat.id !== id,
+      );
 
       if (isDuplicate) {
-        newErrors.name = 'このカテゴリ名は既に存在します'
+        newErrors.name = "このカテゴリ名は既に存在します";
       }
     }
 
-    setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
-  }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
 
   const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault()
+    event.preventDefault();
 
     if (!validateForm()) {
-      return
+      return;
     }
 
     const submitData: CategoryFormData = {
       name: formData.name.trim(),
       color: formData.color,
       description: formData.description?.trim(),
-    }
+    };
 
     if (isEdit && id) {
-      updateCategory(id, submitData)
+      updateCategory(id, submitData);
     } else {
-      createCategory(submitData)
+      createCategory(submitData);
     }
 
-    navigate('/categories')
-  }
+    navigate("/categories");
+  };
 
   const handleCancel = () => {
-    navigate('/categories')
-  }
+    navigate("/categories");
+  };
 
   return (
     <Box sx={{ flex: 1 }}>
       <Paper elevation={3} sx={{ p: 4, mt: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          {isEdit ? 'カテゴリ編集' : 'カテゴリ新規作成'}
+          {isEdit ? "カテゴリ編集" : "カテゴリ新規作成"}
         </Typography>
 
         <Box component="form" onSubmit={handleSubmit} sx={{ mt: 3 }}>
@@ -127,7 +130,7 @@ export const CategoryForm = () => {
               fullWidth
               label="カテゴリ名"
               value={formData.name}
-              onChange={handleChange('name')}
+              onChange={handleChange("name")}
               error={!!errors.name}
               helperText={errors.name}
               required
@@ -138,7 +141,7 @@ export const CategoryForm = () => {
               label="色"
               type="color"
               value={formData.color}
-              onChange={handleChange('color')}
+              onChange={handleChange("color")}
               sx={{ maxWidth: 200 }}
             />
 
@@ -148,12 +151,12 @@ export const CategoryForm = () => {
               multiline
               rows={3}
               value={formData.description}
-              onChange={handleChange('description')}
+              onChange={handleChange("description")}
             />
 
             <Stack direction="row" spacing={2} sx={{ mt: 4 }}>
               <Button type="submit" variant="contained" color="primary">
-                {isEdit ? '更新' : '作成'}
+                {isEdit ? "更新" : "作成"}
               </Button>
 
               <Button variant="outlined" onClick={handleCancel}>
@@ -164,5 +167,5 @@ export const CategoryForm = () => {
         </Box>
       </Paper>
     </Box>
-  )
-}
+  );
+};

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -12,21 +12,21 @@ import {
   Chip,
   Switch,
   FormControlLabel,
-} from '@mui/material'
+} from "@mui/material";
 import {
   FilterList as FilterIcon,
   Clear as ClearIcon,
-} from '@mui/icons-material'
-import type { FilterState } from '../types/filter'
-import type { Category } from '../types/category'
+} from "@mui/icons-material";
+import type { FilterState } from "../types/filter";
+import type { Category } from "../types/category";
 
 interface FilterBarProps {
-  filters: FilterState
-  onFiltersChange: (filters: Partial<FilterState>) => void
-  onReset: () => void
-  categories: Category[]
-  availableTags: string[]
-  activeFilterCount: number
+  filters: FilterState;
+  onFiltersChange: (filters: Partial<FilterState>) => void;
+  onReset: () => void;
+  categories: Category[];
+  availableTags: string[];
+  activeFilterCount: number;
 }
 
 export const FilterBar = ({
@@ -39,42 +39,42 @@ export const FilterBar = ({
 }: FilterBarProps) => {
   const handleCompletionStatusChange = (
     _event: React.MouseEvent<HTMLElement>,
-    newStatus: FilterState['completionStatus'] | null
+    newStatus: FilterState["completionStatus"] | null,
   ) => {
     if (newStatus !== null) {
-      onFiltersChange({ completionStatus: newStatus })
+      onFiltersChange({ completionStatus: newStatus });
     }
-  }
+  };
 
   const handleCategoriesChange = (
     _event: React.SyntheticEvent,
-    newValue: Category[]
+    newValue: Category[],
   ) => {
     onFiltersChange({
-      categoryIds: newValue.map(category => category.id),
-    })
-  }
+      categoryIds: newValue.map((category) => category.id),
+    });
+  };
 
   const handleTagsChange = (
     _event: React.SyntheticEvent,
-    newTags: string[]
+    newTags: string[],
   ) => {
-    onFiltersChange({ tags: newTags })
-  }
+    onFiltersChange({ tags: newTags });
+  };
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onFiltersChange({ searchText: event.target.value })
-  }
+    onFiltersChange({ searchText: event.target.value });
+  };
 
   const handleTagConditionChange = (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    onFiltersChange({ tagCondition: event.target.checked ? 'all' : 'any' })
-  }
+    onFiltersChange({ tagCondition: event.target.checked ? "all" : "any" });
+  };
 
   return (
     <Paper elevation={1} sx={{ p: 2, mb: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+      <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
         <Badge
           badgeContent={activeFilterCount > 0 ? activeFilterCount : undefined}
           color="primary"
@@ -99,10 +99,10 @@ export const FilterBar = ({
 
       <Box
         sx={{
-          display: 'flex',
-          flexWrap: 'wrap',
+          display: "flex",
+          flexWrap: "wrap",
           gap: 2,
-          alignItems: 'flex-start',
+          alignItems: "flex-start",
         }}
       >
         {/* 完了状態フィルター */}
@@ -134,23 +134,23 @@ export const FilterBar = ({
           <Autocomplete
             multiple
             options={categories}
-            value={categories.filter(cat =>
-              filters.categoryIds.includes(cat.id)
+            value={categories.filter((cat) =>
+              filters.categoryIds.includes(cat.id),
             )}
             onChange={handleCategoriesChange}
-            getOptionLabel={option => option.name}
+            getOptionLabel={(option) => option.name}
             renderTags={(tagValue, getTagProps) =>
               tagValue.map((option, index) => (
                 <Chip
                   label={option.name}
                   size="small"
-                  style={{ backgroundColor: option.color, color: 'white' }}
+                  style={{ backgroundColor: option.color, color: "white" }}
                   {...getTagProps({ index })}
                   key={option.id}
                 />
               ))
             }
-            renderInput={params => (
+            renderInput={(params) => (
               <TextField {...params} label="カテゴリ" size="small" />
             )}
             renderOption={(props, option) => (
@@ -158,7 +158,7 @@ export const FilterBar = ({
                 <Chip
                   label={option.name}
                   size="small"
-                  style={{ backgroundColor: option.color, color: 'white' }}
+                  style={{ backgroundColor: option.color, color: "white" }}
                 />
               </li>
             )}
@@ -182,7 +182,7 @@ export const FilterBar = ({
                 />
               ))
             }
-            renderInput={params => (
+            renderInput={(params) => (
               <TextField
                 {...params}
                 label="タグ"
@@ -194,12 +194,12 @@ export const FilterBar = ({
           <FormControlLabel
             control={
               <Switch
-                checked={filters.tagCondition === 'all'}
+                checked={filters.tagCondition === "all"}
                 onChange={handleTagConditionChange}
                 size="small"
               />
             }
-            label={`タグ条件: ${filters.tagCondition === 'all' ? 'すべて' : 'いずれか'}`}
+            label={`タグ条件: ${filters.tagCondition === "all" ? "すべて" : "いずれか"}`}
             sx={{ mt: 0.5 }}
           />
         </Box>
@@ -215,5 +215,5 @@ export const FilterBar = ({
         />
       </Box>
     </Paper>
-  )
-}
+  );
+};

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,47 +1,47 @@
-import { memo } from 'react'
-import { AppBar, Tabs, Tab, styled, IconButton, Box } from '@mui/material'
+import { memo } from "react";
+import { AppBar, Tabs, Tab, styled, IconButton, Box } from "@mui/material";
 import {
   LightMode as LightModeIcon,
   DarkMode as DarkModeIcon,
-} from '@mui/icons-material'
-import { Link, useLocation } from 'react-router-dom'
+} from "@mui/icons-material";
+import { Link, useLocation } from "react-router-dom";
 
 const StyledTabs = styled(Tabs)(({ theme }) => ({
-  '& .MuiTab-root': {
+  "& .MuiTab-root": {
     color:
-      theme.palette.mode === 'dark'
+      theme.palette.mode === "dark"
         ? theme.palette.grey[300]
         : theme.palette.primary.contrastText,
   },
-  '& .MuiTab-root.Mui-selected': {
+  "& .MuiTab-root.Mui-selected": {
     color: theme.palette.common.white,
-    fontWeight: 'bold',
+    fontWeight: "bold",
   },
-}))
+}));
 
 interface NavigationProps {
-  isDarkMode: boolean
-  toggleDarkMode: () => void
+  isDarkMode: boolean;
+  toggleDarkMode: () => void;
 }
 
 export const Navigation = memo(
   ({ isDarkMode, toggleDarkMode }: NavigationProps) => {
-    const location = useLocation()
+    const location = useLocation();
 
     // 現在のパスに基づいてタブの値を決定
     const getTabValue = () => {
-      if (location.pathname === '/') return 0
-      if (location.pathname.startsWith('/categories')) return 1
-      return false // どのタブにも該当しない場合
-    }
+      if (location.pathname === "/") return 0;
+      if (location.pathname.startsWith("/categories")) return 1;
+      return false; // どのタブにも該当しない場合
+    };
 
     return (
       <AppBar position="static">
         <Box
           sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
           }}
         >
           <StyledTabs value={getTabValue()} aria-label="navigation tabs">
@@ -57,7 +57,7 @@ export const Navigation = memo(
             onClick={toggleDarkMode}
             color="inherit"
             aria-label={
-              isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'
+              isDarkMode ? "Switch to light mode" : "Switch to dark mode"
             }
             sx={{ mr: 2 }}
           >
@@ -65,6 +65,6 @@ export const Navigation = memo(
           </IconButton>
         </Box>
       </AppBar>
-    )
-  }
-)
+    );
+  },
+);

--- a/frontend/src/components/NotFoundPage.tsx
+++ b/frontend/src/components/NotFoundPage.tsx
@@ -1,30 +1,33 @@
-import { useNavigate } from 'react-router-dom'
-import { Paper, Box, Typography, Button, Stack } from '@mui/material'
-import { Home as HomeIcon, Category as CategoryIcon } from '@mui/icons-material'
+import { useNavigate } from "react-router-dom";
+import { Paper, Box, Typography, Button, Stack } from "@mui/material";
+import {
+  Home as HomeIcon,
+  Category as CategoryIcon,
+} from "@mui/icons-material";
 
 export const NotFoundPage = () => {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
 
   const handleGoHome = () => {
-    navigate('/')
-  }
+    navigate("/");
+  };
 
   const handleGoCategories = () => {
-    navigate('/categories')
-  }
+    navigate("/categories");
+  };
 
   return (
-    <Box sx={{ flex: 1, display: 'flex', alignItems: 'center' }}>
+    <Box sx={{ flex: 1, display: "flex", alignItems: "center" }}>
       <Paper
         elevation={3}
-        sx={{ p: 6, mt: 8, textAlign: 'center', width: '100%' }}
+        sx={{ p: 6, mt: 8, textAlign: "center", width: "100%" }}
       >
         <Box mb={4}>
           <Typography
             variant="h1"
             component="h1"
             color="error"
-            sx={{ fontSize: '6rem', fontWeight: 'bold' }}
+            sx={{ fontSize: "6rem", fontWeight: "bold" }}
           >
             404
           </Typography>
@@ -67,5 +70,5 @@ export const NotFoundPage = () => {
         </Stack>
       </Paper>
     </Box>
-  )
-}
+  );
+};

--- a/frontend/src/components/SortableTodoItem.tsx
+++ b/frontend/src/components/SortableTodoItem.tsx
@@ -1,17 +1,17 @@
-import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { DragIndicator } from '@mui/icons-material'
-import { Box, IconButton } from '@mui/material'
-import type { Todo, EditTodoData } from '../types/todo'
-import type { Category } from '../types/category'
-import { TodoItem } from './TodoItem'
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { DragIndicator } from "@mui/icons-material";
+import { Box, IconButton } from "@mui/material";
+import type { Todo, EditTodoData } from "../types/todo";
+import type { Category } from "../types/category";
+import { TodoItem } from "./TodoItem";
 
 interface SortableTodoItemProps {
-  todo: Todo
-  onToggle: (id: string) => void
-  onDelete: (id: string) => void
-  onEdit?: (id: string, data: EditTodoData) => void
-  categories: Category[]
+  todo: Todo;
+  onToggle: (id: string) => void;
+  onDelete: (id: string) => void;
+  onEdit?: (id: string, data: EditTodoData) => void;
+  categories: Category[];
 }
 
 export const SortableTodoItem = ({
@@ -28,22 +28,22 @@ export const SortableTodoItem = ({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: todo.id })
+  } = useSortable({ id: todo.id });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-  }
+  };
 
   return (
     <Box
       ref={setNodeRef}
       style={style}
       sx={{
-        display: 'flex',
-        alignItems: 'center',
-        '&:hover .drag-handle': {
+        display: "flex",
+        alignItems: "center",
+        "&:hover .drag-handle": {
           opacity: 1,
         },
       }}
@@ -54,10 +54,10 @@ export const SortableTodoItem = ({
         {...listeners}
         sx={{
           opacity: 0,
-          transition: 'opacity 0.2s',
-          cursor: 'grab',
-          '&:active': {
-            cursor: 'grabbing',
+          transition: "opacity 0.2s",
+          cursor: "grab",
+          "&:active": {
+            cursor: "grabbing",
           },
         }}
         size="small"
@@ -75,5 +75,5 @@ export const SortableTodoItem = ({
         />
       </Box>
     </Box>
-  )
-}
+  );
+};

--- a/frontend/src/components/TodoApp.tsx
+++ b/frontend/src/components/TodoApp.tsx
@@ -1,18 +1,21 @@
-import { DndContext, closestCenter } from '@dnd-kit/core'
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
-import { Box, List, Paper, Typography } from '@mui/material'
-import { useMemo } from 'react'
-import { useCategoryManagement } from '../hooks/useCategoryManagement'
-import { useFilters } from '../hooks/useFilters'
-import { useLocalStorage } from '../hooks/useLocalStorage'
-import { useTodoSorting } from '../hooks/useTodoSorting'
-import type { EditTodoData, Todo } from '../types/todo'
-import { FilterBar } from './FilterBar'
-import { SortableTodoItem } from './SortableTodoItem'
-import { TodoForm } from './TodoForm'
+import { DndContext, closestCenter } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Box, List, Paper, Typography } from "@mui/material";
+import { useMemo } from "react";
+import { useCategoryManagement } from "../hooks/useCategoryManagement";
+import { useFilters } from "../hooks/useFilters";
+import { useLocalStorage } from "../hooks/useLocalStorage";
+import { useTodoSorting } from "../hooks/useTodoSorting";
+import type { EditTodoData, Todo } from "../types/todo";
+import { FilterBar } from "./FilterBar";
+import { SortableTodoItem } from "./SortableTodoItem";
+import { TodoForm } from "./TodoForm";
 
 export const TodoApp = () => {
-  const [storedTodos, setStoredTodos] = useLocalStorage<Todo[]>('todos', [])
+  const [storedTodos, setStoredTodos] = useLocalStorage<Todo[]>("todos", []);
 
   // localStorageから読み込んだTodoを正規化（tagsフィールドとorderフィールドが欠けている可能性に対応）
   const todos = useMemo(
@@ -22,24 +25,24 @@ export const TodoApp = () => {
         tags: todo.tags || [],
         order: todo.order !== undefined ? todo.order : index,
       })),
-    [storedTodos]
-  )
+    [storedTodos],
+  );
 
   const setTodos = (value: Todo[] | ((prev: Todo[]) => Todo[])) => {
-    if (typeof value === 'function') {
-      setStoredTodos(prev => {
+    if (typeof value === "function") {
+      setStoredTodos((prev) => {
         const normalized = prev.map((todo, index) => ({
           ...todo,
           tags: todo.tags || [],
           order: todo.order !== undefined ? todo.order : index,
-        }))
-        return value(normalized)
-      })
+        }));
+        return value(normalized);
+      });
     } else {
-      setStoredTodos(value)
+      setStoredTodos(value);
     }
-  }
-  const { categories } = useCategoryManagement()
+  };
+  const { categories } = useCategoryManagement();
   const {
     filters,
     filteredTodos,
@@ -47,18 +50,21 @@ export const TodoApp = () => {
     resetFilters,
     availableTags,
     activeFilterCount,
-  } = useFilters(todos)
+  } = useFilters(todos);
 
   // ドラッグ&ドロップによる並び替え機能
-  const { sortedTodos, handleDragEnd } = useTodoSorting(filteredTodos, setTodos)
+  const { sortedTodos, handleDragEnd } = useTodoSorting(
+    filteredTodos,
+    setTodos,
+  );
 
   const handleAddTodo = (data: {
-    text: string
-    categoryId?: string
-    tags: string[]
+    text: string;
+    categoryId?: string;
+    tags: string[];
   }) => {
     const maxOrder =
-      todos.length > 0 ? Math.max(...todos.map(t => t.order || 0)) : -1
+      todos.length > 0 ? Math.max(...todos.map((t) => t.order || 0)) : -1;
     const newTodo: Todo = {
       id: Date.now().toString(),
       text: data.text,
@@ -67,26 +73,26 @@ export const TodoApp = () => {
       categoryId: data.categoryId,
       tags: data.tags,
       order: maxOrder + 1,
-    }
+    };
 
-    setTodos(prev => [...prev, newTodo])
-  }
+    setTodos((prev) => [...prev, newTodo]);
+  };
 
   const handleToggleTodo = (id: string) => {
-    setTodos(prev =>
-      prev.map(todo =>
-        todo.id === id ? { ...todo, completed: !todo.completed } : todo
-      )
-    )
-  }
+    setTodos((prev) =>
+      prev.map((todo) =>
+        todo.id === id ? { ...todo, completed: !todo.completed } : todo,
+      ),
+    );
+  };
 
   const handleDeleteTodo = (id: string) => {
-    setTodos(prev => prev.filter(todo => todo.id !== id))
-  }
+    setTodos((prev) => prev.filter((todo) => todo.id !== id));
+  };
 
   const handleEditTodo = (id: string, data: EditTodoData) => {
-    setTodos(prev =>
-      prev.map(todo =>
+    setTodos((prev) =>
+      prev.map((todo) =>
         todo.id === id
           ? {
               ...todo,
@@ -94,10 +100,10 @@ export const TodoApp = () => {
               categoryId: data.categoryId,
               tags: data.tags,
             }
-          : todo
-      )
-    )
-  }
+          : todo,
+      ),
+    );
+  };
 
   return (
     <Box sx={{ flex: 1 }}>
@@ -124,11 +130,11 @@ export const TodoApp = () => {
               onDragEnd={handleDragEnd}
             >
               <SortableContext
-                items={sortedTodos.map(todo => todo.id)}
+                items={sortedTodos.map((todo) => todo.id)}
                 strategy={verticalListSortingStrategy}
               >
                 <List>
-                  {sortedTodos.map(todo => (
+                  {sortedTodos.map((todo) => (
                     <SortableTodoItem
                       key={todo.id}
                       todo={todo}
@@ -167,5 +173,5 @@ export const TodoApp = () => {
         )}
       </Paper>
     </Box>
-  )
-}
+  );
+};

--- a/frontend/src/components/TodoEditForm.tsx
+++ b/frontend/src/components/TodoEditForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef } from "react";
 import {
   Box,
   TextField,
@@ -8,18 +8,18 @@ import {
   FormControl,
   InputLabel,
   Paper,
-} from '@mui/material'
-import type { SelectChangeEvent } from '@mui/material'
-import { Check as CheckIcon, Close as CloseIcon } from '@mui/icons-material'
-import type { EditTodoData } from '../types/todo'
-import type { Category } from '../types/category'
+} from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material";
+import { Check as CheckIcon, Close as CloseIcon } from "@mui/icons-material";
+import type { EditTodoData } from "../types/todo";
+import type { Category } from "../types/category";
 
 interface TodoEditFormProps {
-  editData: EditTodoData
-  categories: Category[]
-  onSave: () => void
-  onCancel: () => void
-  onUpdateData: (data: Partial<EditTodoData>) => void
+  editData: EditTodoData;
+  categories: Category[];
+  onSave: () => void;
+  onCancel: () => void;
+  onUpdateData: (data: Partial<EditTodoData>) => void;
 }
 
 export const TodoEditForm = ({
@@ -29,49 +29,49 @@ export const TodoEditForm = ({
   onCancel,
   onUpdateData,
 }: TodoEditFormProps) => {
-  const textInputRef = useRef<HTMLInputElement>(null)
+  const textInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (textInputRef.current) {
-      textInputRef.current.focus()
+      textInputRef.current.focus();
     }
-  }, [])
+  }, []);
 
   const handleTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onUpdateData({ text: event.target.value })
-  }
+    onUpdateData({ text: event.target.value });
+  };
 
   const handleCategoryChange = (event: SelectChangeEvent) => {
-    const categoryId = event.target.value || undefined
-    onUpdateData({ categoryId })
-  }
+    const categoryId = event.target.value || undefined;
+    onUpdateData({ categoryId });
+  };
 
   const handleTagsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const tagsInput = event.target.value
+    const tagsInput = event.target.value;
     const tags = tagsInput
-      .split(',')
-      .map(tag => tag.trim())
-      .filter(tag => tag.length > 0)
-    onUpdateData({ tags })
-  }
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+    onUpdateData({ tags });
+  };
 
   const handleKeyPress = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      onSave()
+    if (event.key === "Enter") {
+      onSave();
     }
-  }
+  };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      onCancel()
+    if (event.key === "Escape") {
+      onCancel();
     }
-  }
+  };
 
-  const tagsInputValue = editData.tags.join(', ')
+  const tagsInputValue = editData.tags.join(", ");
 
   return (
     <Paper elevation={2} sx={{ p: 2, mb: 1 }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         {/* テキスト入力 */}
         <TextField
           inputRef={textInputRef}
@@ -87,20 +87,20 @@ export const TodoEditForm = ({
         />
 
         {/* カテゴリとタグの入力行 */}
-        <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+        <Box sx={{ display: "flex", gap: 2, alignItems: "flex-start" }}>
           {/* カテゴリ選択 */}
           <FormControl size="small" sx={{ minWidth: 120 }}>
             <InputLabel id="edit-category-select-label">カテゴリ</InputLabel>
             <Select
               labelId="edit-category-select-label"
-              value={editData.categoryId || ''}
+              value={editData.categoryId || ""}
               label="カテゴリ"
               onChange={handleCategoryChange}
             >
               <MenuItem value="">
                 <em>なし</em>
               </MenuItem>
-              {categories.map(category => (
+              {categories.map((category) => (
                 <MenuItem key={category.id} value={category.id}>
                   {category.name}
                 </MenuItem>
@@ -120,7 +120,7 @@ export const TodoEditForm = ({
           />
 
           {/* アクションボタン */}
-          <Box sx={{ display: 'flex', gap: 1 }}>
+          <Box sx={{ display: "flex", gap: 1 }}>
             <Button
               variant="contained"
               size="small"
@@ -142,5 +142,5 @@ export const TodoEditForm = ({
         </Box>
       </Box>
     </Paper>
-  )
-}
+  );
+};

--- a/frontend/src/components/TodoForm.tsx
+++ b/frontend/src/components/TodoForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState } from "react";
 import {
   Box,
   TextField,
@@ -8,72 +8,72 @@ import {
   FormControl,
   InputLabel,
   Paper,
-} from '@mui/material'
-import type { SelectChangeEvent } from '@mui/material'
-import { Add as AddIcon } from '@mui/icons-material'
-import type { Category } from '../types/category'
+} from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material";
+import { Add as AddIcon } from "@mui/icons-material";
+import type { Category } from "../types/category";
 
 interface TodoFormData {
-  text: string
-  categoryId?: string
-  tags: string[]
+  text: string;
+  categoryId?: string;
+  tags: string[];
 }
 
 interface TodoFormProps {
-  onSubmit: (data: TodoFormData) => void
-  categories: Category[]
+  onSubmit: (data: TodoFormData) => void;
+  categories: Category[];
 }
 
 export const TodoForm = ({ onSubmit, categories }: TodoFormProps) => {
-  const [text, setText] = useState('')
-  const [categoryId, setCategoryId] = useState<string>('')
-  const [tagsInput, setTagsInput] = useState('')
+  const [text, setText] = useState("");
+  const [categoryId, setCategoryId] = useState<string>("");
+  const [tagsInput, setTagsInput] = useState("");
 
   const handleSubmit = () => {
-    if (text.trim() === '') return
+    if (text.trim() === "") return;
 
     const tags = tagsInput
-      .split(',')
-      .map(tag => tag.trim())
-      .filter(tag => tag.length > 0)
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
 
     onSubmit({
       text: text.trim(),
       categoryId: categoryId || undefined,
       tags,
-    })
+    });
 
     // フォームをクリア
-    setText('')
-    setCategoryId('')
-    setTagsInput('')
-  }
+    setText("");
+    setCategoryId("");
+    setTagsInput("");
+  };
 
   const handleKeyPress = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      handleSubmit()
+    if (event.key === "Enter") {
+      handleSubmit();
     }
-  }
+  };
 
   const handleCategoryChange = (event: SelectChangeEvent) => {
-    setCategoryId(event.target.value)
-  }
+    setCategoryId(event.target.value);
+  };
 
   return (
     <Paper elevation={3} sx={{ p: 3, mb: 3 }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         {/* テキスト入力 */}
         <TextField
           fullWidth
           variant="outlined"
           placeholder="新しいタスクを入力"
           value={text}
-          onChange={e => setText(e.target.value)}
+          onChange={(e) => setText(e.target.value)}
           onKeyPress={handleKeyPress}
         />
 
         {/* カテゴリとタグの入力行 */}
-        <Box sx={{ display: 'flex', gap: 2 }}>
+        <Box sx={{ display: "flex", gap: 2 }}>
           {/* カテゴリ選択 */}
           <FormControl sx={{ minWidth: 150 }}>
             <InputLabel id="category-select-label">カテゴリ</InputLabel>
@@ -86,7 +86,7 @@ export const TodoForm = ({ onSubmit, categories }: TodoFormProps) => {
               <MenuItem value="">
                 <em>なし</em>
               </MenuItem>
-              {categories.map(category => (
+              {categories.map((category) => (
                 <MenuItem key={category.id} value={category.id}>
                   {category.name}
                 </MenuItem>
@@ -101,7 +101,7 @@ export const TodoForm = ({ onSubmit, categories }: TodoFormProps) => {
             label="タグ"
             placeholder="タグをカンマ区切りで入力"
             value={tagsInput}
-            onChange={e => setTagsInput(e.target.value)}
+            onChange={(e) => setTagsInput(e.target.value)}
             helperText="例: 重要, 急ぎ, 今日中"
           />
 
@@ -110,12 +110,12 @@ export const TodoForm = ({ onSubmit, categories }: TodoFormProps) => {
             variant="contained"
             onClick={handleSubmit}
             startIcon={<AddIcon />}
-            sx={{ minWidth: 120, height: 'fit-content' }}
+            sx={{ minWidth: 120, height: "fit-content" }}
           >
             追加
           </Button>
         </Box>
       </Box>
     </Paper>
-  )
-}
+  );
+};

--- a/frontend/src/components/TodoItem.tsx
+++ b/frontend/src/components/TodoItem.tsx
@@ -8,19 +8,19 @@ import {
   Typography,
   Chip,
   Box,
-} from '@mui/material'
-import { Delete as DeleteIcon, Edit as EditIcon } from '@mui/icons-material'
-import type { Todo, EditTodoData } from '../types/todo'
-import type { Category } from '../types/category'
-import { TodoEditForm } from './TodoEditForm'
-import { useEditTodo } from '../hooks/useEditTodo'
+} from "@mui/material";
+import { Delete as DeleteIcon, Edit as EditIcon } from "@mui/icons-material";
+import type { Todo, EditTodoData } from "../types/todo";
+import type { Category } from "../types/category";
+import { TodoEditForm } from "./TodoEditForm";
+import { useEditTodo } from "../hooks/useEditTodo";
 
 interface TodoItemProps {
-  todo: Todo
-  onToggle: (id: string) => void
-  onDelete: (id: string) => void
-  onEdit?: (id: string, data: EditTodoData) => void
-  categories?: Category[]
+  todo: Todo;
+  onToggle: (id: string) => void;
+  onDelete: (id: string) => void;
+  onEdit?: (id: string, data: EditTodoData) => void;
+  categories?: Category[];
 }
 
 export const TodoItem = ({
@@ -31,16 +31,16 @@ export const TodoItem = ({
   categories = [],
 }: TodoItemProps) => {
   const category = todo.categoryId
-    ? categories.find(cat => cat.id === todo.categoryId)
-    : undefined
+    ? categories.find((cat) => cat.id === todo.categoryId)
+    : undefined;
 
-  const editTodo = useEditTodo(todo, onEdit || (() => {}))
+  const editTodo = useEditTodo(todo, onEdit || (() => {}));
 
   const handleDoubleClick = () => {
     if (onEdit) {
-      editTodo.startEdit()
+      editTodo.startEdit();
     }
-  }
+  };
 
   if (editTodo.isEditing) {
     return (
@@ -51,13 +51,13 @@ export const TodoItem = ({
         onCancel={editTodo.cancelEdit}
         onUpdateData={editTodo.updateEditData}
       />
-    )
+    );
   }
 
   return (
     <ListItem
       secondaryAction={
-        <Box sx={{ display: 'flex', gap: 1 }}>
+        <Box sx={{ display: "flex", gap: 1 }}>
           {onEdit && (
             <IconButton
               edge="end"
@@ -99,8 +99,8 @@ export const TodoItem = ({
               <Typography
                 variant="body1"
                 sx={{
-                  textDecoration: todo.completed ? 'line-through' : 'none',
-                  color: todo.completed ? 'text.secondary' : 'text.primary',
+                  textDecoration: todo.completed ? "line-through" : "none",
+                  color: todo.completed ? "text.secondary" : "text.primary",
                   mb: category || (todo.tags && todo.tags.length > 0) ? 1 : 0,
                 }}
               >
@@ -109,7 +109,7 @@ export const TodoItem = ({
 
               {/* カテゴリとタグのChip表示 */}
               {(category || (todo.tags && todo.tags.length > 0)) && (
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
                   {/* カテゴリChip */}
                   {category && (
                     <Chip
@@ -117,8 +117,8 @@ export const TodoItem = ({
                       size="small"
                       sx={{
                         backgroundColor: category.color,
-                        color: 'white',
-                        fontSize: '0.75rem',
+                        color: "white",
+                        fontSize: "0.75rem",
                       }}
                     />
                   )}
@@ -127,7 +127,7 @@ export const TodoItem = ({
                   {todo.tags && todo.tags.length > 0 && (
                     <Box
                       data-testid="tags-container"
-                      sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}
+                      sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}
                     >
                       {todo.tags.map((tag, index) => (
                         <Chip
@@ -135,7 +135,7 @@ export const TodoItem = ({
                           label={tag}
                           size="small"
                           variant="outlined"
-                          sx={{ fontSize: '0.75rem' }}
+                          sx={{ fontSize: "0.75rem" }}
                         />
                       ))}
                     </Box>
@@ -147,5 +147,5 @@ export const TodoItem = ({
         />
       </ListItemButton>
     </ListItem>
-  )
-}
+  );
+};

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -1,89 +1,89 @@
-import { useCallback } from 'react'
-import type { Category } from '../types/category'
-import { useLocalStorage } from './useLocalStorage'
+import { useCallback } from "react";
+import type { Category } from "../types/category";
+import { useLocalStorage } from "./useLocalStorage";
 
 const DEFAULT_CATEGORIES: Category[] = [
   {
-    id: 'work',
-    name: '仕事',
-    color: '#1976d2',
-    description: '仕事関連のタスク',
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
+    id: "work",
+    name: "仕事",
+    color: "#1976d2",
+    description: "仕事関連のタスク",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
   },
   {
-    id: 'private',
-    name: 'プライベート',
-    color: '#ff5722',
-    description: '個人的なタスク',
-    createdAt: new Date('2024-01-02'),
-    updatedAt: new Date('2024-01-02'),
+    id: "private",
+    name: "プライベート",
+    color: "#ff5722",
+    description: "個人的なタスク",
+    createdAt: new Date("2024-01-02"),
+    updatedAt: new Date("2024-01-02"),
   },
   {
-    id: 'other',
-    name: 'その他',
-    color: '#9e9e9e',
-    description: 'その他のタスク',
-    createdAt: new Date('2024-01-03'),
-    updatedAt: new Date('2024-01-03'),
+    id: "other",
+    name: "その他",
+    color: "#9e9e9e",
+    description: "その他のタスク",
+    createdAt: new Date("2024-01-03"),
+    updatedAt: new Date("2024-01-03"),
   },
-]
+];
 
 export const useCategories = () => {
   const [categories, setCategories] = useLocalStorage<Category[]>(
-    'categories',
-    DEFAULT_CATEGORIES
-  )
+    "categories",
+    DEFAULT_CATEGORIES,
+  );
 
   const addCategory = useCallback(
     (name: string, color: string) => {
       // 同じ名前のカテゴリが既に存在するかチェック
-      const exists = categories.some(category => category.name === name)
+      const exists = categories.some((category) => category.name === name);
       if (exists) {
-        return
+        return;
       }
 
-      const now = new Date()
+      const now = new Date();
       const newCategory: Category = {
         id: `cat-${Date.now()}`,
         name,
         color,
-        description: '',
+        description: "",
         createdAt: now,
         updatedAt: now,
-      }
+      };
 
-      setCategories(prev => [...prev, newCategory])
+      setCategories((prev) => [...prev, newCategory]);
     },
-    [categories, setCategories]
-  )
+    [categories, setCategories],
+  );
 
   const updateCategory = useCallback(
     (id: string, name: string, color: string) => {
-      setCategories(prev =>
-        prev.map(category =>
+      setCategories((prev) =>
+        prev.map((category) =>
           category.id === id
             ? { ...category, name, color, updatedAt: new Date() }
-            : category
-        )
-      )
+            : category,
+        ),
+      );
     },
-    [setCategories]
-  )
+    [setCategories],
+  );
 
   const deleteCategory = useCallback(
     (id: string) => {
-      setCategories(prev => prev.filter(category => category.id !== id))
+      setCategories((prev) => prev.filter((category) => category.id !== id));
     },
-    [setCategories]
-  )
+    [setCategories],
+  );
 
   const getCategoryById = useCallback(
     (id: string): Category | undefined => {
-      return categories.find(category => category.id === id)
+      return categories.find((category) => category.id === id);
     },
-    [categories]
-  )
+    [categories],
+  );
 
   return {
     categories,
@@ -91,5 +91,5 @@ export const useCategories = () => {
     updateCategory,
     deleteCategory,
     getCategoryById,
-  }
-}
+  };
+};

--- a/frontend/src/hooks/useCategoryManagement.ts
+++ b/frontend/src/hooks/useCategoryManagement.ts
@@ -1,55 +1,55 @@
-import { useCallback } from 'react'
+import { useCallback } from "react";
 import type {
   Category,
   CategoryFormData,
   UseCategoryManagementReturn,
-} from '../types/category'
-import { useLocalStorage } from './useLocalStorage'
+} from "../types/category";
+import { useLocalStorage } from "./useLocalStorage";
 
 const DEFAULT_CATEGORIES: Category[] = [
   {
-    id: 'work',
-    name: '仕事',
-    color: '#1976d2',
-    description: '仕事関連のタスク',
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
+    id: "work",
+    name: "仕事",
+    color: "#1976d2",
+    description: "仕事関連のタスク",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
   },
   {
-    id: 'private',
-    name: 'プライベート',
-    color: '#ff5722',
-    description: '個人的なタスク',
-    createdAt: new Date('2024-01-02'),
-    updatedAt: new Date('2024-01-02'),
+    id: "private",
+    name: "プライベート",
+    color: "#ff5722",
+    description: "個人的なタスク",
+    createdAt: new Date("2024-01-02"),
+    updatedAt: new Date("2024-01-02"),
   },
   {
-    id: 'other',
-    name: 'その他',
-    color: '#9e9e9e',
-    description: 'その他のタスク',
-    createdAt: new Date('2024-01-03'),
-    updatedAt: new Date('2024-01-03'),
+    id: "other",
+    name: "その他",
+    color: "#9e9e9e",
+    description: "その他のタスク",
+    createdAt: new Date("2024-01-03"),
+    updatedAt: new Date("2024-01-03"),
   },
-]
+];
 
 export const useCategoryManagement = (): UseCategoryManagementReturn => {
   const [categories, setCategories] = useLocalStorage<Category[]>(
-    'categories',
-    DEFAULT_CATEGORIES
-  )
+    "categories",
+    DEFAULT_CATEGORIES,
+  );
 
   // カテゴリの使用状況チェック機能
   // 現在はサンプルデータで動作確認済み
   const createCategory = useCallback(
     (data: CategoryFormData) => {
       // 同じ名前のカテゴリが既に存在するかチェック
-      const exists = categories.some(category => category.name === data.name)
+      const exists = categories.some((category) => category.name === data.name);
       if (exists) {
-        return
+        return;
       }
 
-      const now = new Date()
+      const now = new Date();
       const newCategory: Category = {
         id: `cat-${Date.now()}`,
         name: data.name,
@@ -57,17 +57,17 @@ export const useCategoryManagement = (): UseCategoryManagementReturn => {
         description: data.description,
         createdAt: now,
         updatedAt: now,
-      }
+      };
 
-      setCategories(prev => [...prev, newCategory])
+      setCategories((prev) => [...prev, newCategory]);
     },
-    [categories, setCategories]
-  )
+    [categories, setCategories],
+  );
 
   const updateCategory = useCallback(
     (id: string, data: CategoryFormData) => {
-      setCategories(prev =>
-        prev.map(category =>
+      setCategories((prev) =>
+        prev.map((category) =>
           category.id === id
             ? {
                 ...category,
@@ -76,39 +76,39 @@ export const useCategoryManagement = (): UseCategoryManagementReturn => {
                 description: data.description,
                 updatedAt: new Date(),
               }
-            : category
-        )
-      )
+            : category,
+        ),
+      );
     },
-    [setCategories]
-  )
+    [setCategories],
+  );
 
   const isCategoryInUse = useCallback((id: string): boolean => {
     // カテゴリ使用状況の確認（サンプルデータで動作）
     const mockTodos = [
-      { id: '1', categoryId: 'work', title: 'Test Todo', completed: false },
-    ]
-    return mockTodos.some(todo => todo.categoryId === id)
-  }, [])
+      { id: "1", categoryId: "work", title: "Test Todo", completed: false },
+    ];
+    return mockTodos.some((todo) => todo.categoryId === id);
+  }, []);
 
   const deleteCategory = useCallback(
     (id: string): boolean => {
       // カテゴリが存在するかチェック
-      const categoryExists = categories.some(category => category.id === id)
+      const categoryExists = categories.some((category) => category.id === id);
       if (!categoryExists) {
-        return false
+        return false;
       }
 
       // 使用中のカテゴリは削除できない
       if (isCategoryInUse(id)) {
-        return false
+        return false;
       }
 
-      setCategories(prev => prev.filter(category => category.id !== id))
-      return true
+      setCategories((prev) => prev.filter((category) => category.id !== id));
+      return true;
     },
-    [categories, isCategoryInUse, setCategories]
-  )
+    [categories, isCategoryInUse, setCategories],
+  );
 
   return {
     categories,
@@ -116,5 +116,5 @@ export const useCategoryManagement = (): UseCategoryManagementReturn => {
     updateCategory,
     deleteCategory,
     isCategoryInUse,
-  }
-}
+  };
+};

--- a/frontend/src/hooks/useDarkMode.ts
+++ b/frontend/src/hooks/useDarkMode.ts
@@ -1,82 +1,82 @@
-import { useState, useEffect } from 'react'
-import { useLocalStorage } from './useLocalStorage'
+import { useState, useEffect } from "react";
+import { useLocalStorage } from "./useLocalStorage";
 
 export interface UseDarkModeReturn {
-  isDarkMode: boolean
-  toggleDarkMode: () => void
-  setDarkMode: (value: boolean) => void
+  isDarkMode: boolean;
+  toggleDarkMode: () => void;
+  setDarkMode: (value: boolean) => void;
 }
 
 export function useDarkMode(): UseDarkModeReturn {
   // システムのダークモード設定を検出
   const getSystemPreference = (): boolean => {
-    if (typeof window === 'undefined') return false
+    if (typeof window === "undefined") return false;
 
     try {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches
+      return window.matchMedia("(prefers-color-scheme: dark)").matches;
     } catch (error) {
-      console.warn('matchMedia not supported:', error)
-      return false
+      console.warn("matchMedia not supported:", error);
+      return false;
     }
-  }
+  };
 
-  const systemPreference = getSystemPreference()
+  const systemPreference = getSystemPreference();
 
   // localStorageから設定を取得、なければシステム設定を使用
   const [storedDarkMode, setStoredDarkMode] = useLocalStorage<boolean | null>(
-    'darkMode',
-    null
-  )
+    "darkMode",
+    null,
+  );
 
   // 実際のダークモード状態
   const [isDarkMode, setIsDarkMode] = useState<boolean>(
-    storedDarkMode !== null ? storedDarkMode : systemPreference
-  )
+    storedDarkMode !== null ? storedDarkMode : systemPreference,
+  );
 
   // システム設定の変更を監視
   useEffect(() => {
-    if (typeof window === 'undefined') return
+    if (typeof window === "undefined") return;
 
     try {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
       const handleChange = (e: MediaQueryListEvent) => {
         // ユーザーが明示的に設定していない場合のみシステム設定に従う
         if (storedDarkMode === null) {
-          setIsDarkMode(e.matches)
+          setIsDarkMode(e.matches);
         }
-      }
+      };
 
-      mediaQuery.addEventListener('change', handleChange)
-      return () => mediaQuery.removeEventListener('change', handleChange)
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
     } catch (error) {
-      console.warn('Error setting up system preference listener:', error)
+      console.warn("Error setting up system preference listener:", error);
     }
-  }, [storedDarkMode])
+  }, [storedDarkMode]);
 
   // ストレージの値が変更されたときにstateを更新
   useEffect(() => {
     if (storedDarkMode !== null) {
-      setIsDarkMode(storedDarkMode)
+      setIsDarkMode(storedDarkMode);
     } else {
-      setIsDarkMode(getSystemPreference())
+      setIsDarkMode(getSystemPreference());
     }
-  }, [storedDarkMode])
+  }, [storedDarkMode]);
 
   const toggleDarkMode = () => {
-    const newValue = !isDarkMode
-    setStoredDarkMode(newValue)
-    setIsDarkMode(newValue)
-  }
+    const newValue = !isDarkMode;
+    setStoredDarkMode(newValue);
+    setIsDarkMode(newValue);
+  };
 
   const setDarkMode = (value: boolean) => {
-    setStoredDarkMode(value)
-    setIsDarkMode(value)
-  }
+    setStoredDarkMode(value);
+    setIsDarkMode(value);
+  };
 
   return {
     isDarkMode,
     toggleDarkMode,
     setDarkMode,
-  }
+  };
 }

--- a/frontend/src/hooks/useEditTodo.ts
+++ b/frontend/src/hooks/useEditTodo.ts
@@ -1,51 +1,51 @@
-import { useState, useCallback } from 'react'
-import type { Todo, EditTodoData } from '../types/todo'
+import { useState, useCallback } from "react";
+import type { Todo, EditTodoData } from "../types/todo";
 
 export interface UseEditTodoReturn {
-  isEditing: boolean
-  editData: EditTodoData
-  startEdit: () => void
-  cancelEdit: () => void
-  saveEdit: () => void
-  updateEditData: (data: Partial<EditTodoData>) => void
+  isEditing: boolean;
+  editData: EditTodoData;
+  startEdit: () => void;
+  cancelEdit: () => void;
+  saveEdit: () => void;
+  updateEditData: (data: Partial<EditTodoData>) => void;
 }
 
 export const useEditTodo = (
   todo: Todo,
-  onEdit: (id: string, data: EditTodoData) => void
+  onEdit: (id: string, data: EditTodoData) => void,
 ): UseEditTodoReturn => {
-  const [isEditing, setIsEditing] = useState(false)
+  const [isEditing, setIsEditing] = useState(false);
   const [editData, setEditData] = useState<EditTodoData>({
     text: todo.text,
     categoryId: todo.categoryId,
     tags: todo.tags,
-  })
+  });
 
   const startEdit = useCallback(() => {
-    setIsEditing(true)
-  }, [])
+    setIsEditing(true);
+  }, []);
 
   const cancelEdit = useCallback(() => {
-    setIsEditing(false)
+    setIsEditing(false);
     setEditData({
       text: todo.text,
       categoryId: todo.categoryId,
       tags: todo.tags,
-    })
-  }, [todo.text, todo.categoryId, todo.tags])
+    });
+  }, [todo.text, todo.categoryId, todo.tags]);
 
   const updateEditData = useCallback((data: Partial<EditTodoData>) => {
-    setEditData(prev => ({ ...prev, ...data }))
-  }, [])
+    setEditData((prev) => ({ ...prev, ...data }));
+  }, []);
 
   const saveEdit = useCallback(() => {
-    if (editData.text.trim() === '') {
-      return
+    if (editData.text.trim() === "") {
+      return;
     }
 
-    onEdit(todo.id, editData)
-    setIsEditing(false)
-  }, [editData, todo.id, onEdit])
+    onEdit(todo.id, editData);
+    setIsEditing(false);
+  }, [editData, todo.id, onEdit]);
 
   return {
     isEditing,
@@ -54,5 +54,5 @@ export const useEditTodo = (
     cancelEdit,
     saveEdit,
     updateEditData,
-  }
-}
+  };
+};

--- a/frontend/src/hooks/useFilters.ts
+++ b/frontend/src/hooks/useFilters.ts
@@ -1,63 +1,65 @@
-import { useMemo } from 'react'
-import type { Todo } from '../types/todo'
-import type { FilterState } from '../types/filter'
-import { useLocalStorage } from './useLocalStorage'
+import { useMemo } from "react";
+import type { Todo } from "../types/todo";
+import type { FilterState } from "../types/filter";
+import { useLocalStorage } from "./useLocalStorage";
 
 interface UseFiltersReturn {
-  filters: FilterState
-  updateFilters: (filters: Partial<FilterState>) => void
-  resetFilters: () => void
-  filteredTodos: Todo[]
-  availableTags: string[]
-  activeFilterCount: number
+  filters: FilterState;
+  updateFilters: (filters: Partial<FilterState>) => void;
+  resetFilters: () => void;
+  filteredTodos: Todo[];
+  availableTags: string[];
+  activeFilterCount: number;
 }
 
 const defaultFilters: FilterState = {
-  completionStatus: 'all',
+  completionStatus: "all",
   categoryIds: [],
   tags: [],
-  tagCondition: 'any',
-  searchText: '',
-}
+  tagCondition: "any",
+  searchText: "",
+};
 
 export const useFilters = (todos: Todo[]): UseFiltersReturn => {
   const [filters, setStoredFilters] = useLocalStorage<FilterState>(
-    'todoFilters',
-    defaultFilters
-  )
+    "todoFilters",
+    defaultFilters,
+  );
 
   const updateFilters = (newFilters: Partial<FilterState>) => {
-    setStoredFilters(prev => ({ ...prev, ...newFilters }))
-  }
+    setStoredFilters((prev) => ({ ...prev, ...newFilters }));
+  };
 
   const resetFilters = () => {
-    setStoredFilters(defaultFilters)
-  }
+    setStoredFilters(defaultFilters);
+  };
 
   const filteredTodos = useMemo(() => {
-    return todos.filter(todo => {
+    return todos.filter((todo) => {
       // 完了状態フィルター
-      if (filters.completionStatus === 'completed' && !todo.completed)
-        return false
-      if (filters.completionStatus === 'incomplete' && todo.completed)
-        return false
+      if (filters.completionStatus === "completed" && !todo.completed)
+        return false;
+      if (filters.completionStatus === "incomplete" && todo.completed)
+        return false;
 
       // カテゴリフィルター
       if (
         filters.categoryIds.length > 0 &&
-        !filters.categoryIds.includes(todo.categoryId || '')
+        !filters.categoryIds.includes(todo.categoryId || "")
       ) {
-        return false
+        return false;
       }
 
       // タグフィルター
       if (filters.tags.length > 0) {
-        if (filters.tagCondition === 'all') {
+        if (filters.tagCondition === "all") {
           // 全てのタグが含まれている必要がある
-          if (!filters.tags.every(tag => todo.tags.includes(tag))) return false
+          if (!filters.tags.every((tag) => todo.tags.includes(tag)))
+            return false;
         } else {
           // いずれかのタグが含まれている必要がある
-          if (!filters.tags.some(tag => todo.tags.includes(tag))) return false
+          if (!filters.tags.some((tag) => todo.tags.includes(tag)))
+            return false;
         }
       }
 
@@ -66,29 +68,29 @@ export const useFilters = (todos: Todo[]): UseFiltersReturn => {
         filters.searchText &&
         !todo.text.toLowerCase().includes(filters.searchText.toLowerCase())
       ) {
-        return false
+        return false;
       }
 
-      return true
-    })
-  }, [todos, filters])
+      return true;
+    });
+  }, [todos, filters]);
 
   const availableTags = useMemo(() => {
-    const tagsSet = new Set<string>()
-    todos.forEach(todo => {
-      todo.tags.forEach(tag => tagsSet.add(tag))
-    })
-    return Array.from(tagsSet).sort()
-  }, [todos])
+    const tagsSet = new Set<string>();
+    todos.forEach((todo) => {
+      todo.tags.forEach((tag) => tagsSet.add(tag));
+    });
+    return Array.from(tagsSet).sort();
+  }, [todos]);
 
   const activeFilterCount = useMemo(() => {
-    let count = 0
-    if (filters.completionStatus !== 'all') count++
-    if (filters.categoryIds.length > 0) count++
-    if (filters.tags.length > 0) count++
-    if (filters.searchText.trim() !== '') count++
-    return count
-  }, [filters])
+    let count = 0;
+    if (filters.completionStatus !== "all") count++;
+    if (filters.categoryIds.length > 0) count++;
+    if (filters.tags.length > 0) count++;
+    if (filters.searchText.trim() !== "") count++;
+    return count;
+  }, [filters]);
 
   return {
     filters,
@@ -97,5 +99,5 @@ export const useFilters = (todos: Todo[]): UseFiltersReturn => {
     filteredTodos,
     availableTags,
     activeFilterCount,
-  }
-}
+  };
+};

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -1,56 +1,56 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect } from "react";
 
 export function useLocalStorage<T>(
   key: string,
-  initialValue: T
+  initialValue: T,
 ): [T, (value: T | ((val: T) => T)) => void] {
   const [storedValue, setStoredValue] = useState<T>(() => {
-    if (typeof window === 'undefined') {
-      return initialValue
+    if (typeof window === "undefined") {
+      return initialValue;
     }
 
     try {
-      const item = window.localStorage.getItem(key)
-      return item ? JSON.parse(item) : initialValue
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
     } catch (error) {
-      console.warn(`Error reading localStorage key "${key}":`, error)
-      return initialValue
+      console.warn(`Error reading localStorage key "${key}":`, error);
+      return initialValue;
     }
-  })
+  });
 
   const setValue = (value: T | ((val: T) => T)) => {
     try {
       const valueToStore =
-        value instanceof Function ? value(storedValue) : value
-      setStoredValue(valueToStore)
+        value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
 
-      if (typeof window !== 'undefined') {
-        window.localStorage.setItem(key, JSON.stringify(valueToStore))
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
       }
     } catch (error) {
-      console.warn(`Error setting localStorage key "${key}":`, error)
+      console.warn(`Error setting localStorage key "${key}":`, error);
     }
-  }
+  };
 
   useEffect(() => {
     const handleStorageChange = (e: StorageEvent) => {
       if (e.key === key && e.newValue !== null) {
         try {
-          setStoredValue(JSON.parse(e.newValue))
+          setStoredValue(JSON.parse(e.newValue));
         } catch (error) {
           console.warn(
             `Error parsing localStorage value for key "${key}":`,
-            error
-          )
+            error,
+          );
         }
       }
-    }
+    };
 
-    if (typeof window !== 'undefined') {
-      window.addEventListener('storage', handleStorageChange)
-      return () => window.removeEventListener('storage', handleStorageChange)
+    if (typeof window !== "undefined") {
+      window.addEventListener("storage", handleStorageChange);
+      return () => window.removeEventListener("storage", handleStorageChange);
     }
-  }, [key])
+  }, [key]);
 
-  return [storedValue, setValue]
+  return [storedValue, setValue];
 }

--- a/frontend/src/hooks/useTodoSorting.ts
+++ b/frontend/src/hooks/useTodoSorting.ts
@@ -1,99 +1,101 @@
-import { useMemo, useCallback } from 'react'
-import { arrayMove } from '@dnd-kit/sortable'
-import type { DragEndEvent } from '@dnd-kit/core'
-import type { Todo } from '../types/todo'
+import { useMemo, useCallback } from "react";
+import { arrayMove } from "@dnd-kit/sortable";
+import type { DragEndEvent } from "@dnd-kit/core";
+import type { Todo } from "../types/todo";
 
 export interface UseTodoSortingReturn {
-  sortedTodos: Todo[]
-  handleDragEnd: (event: DragEndEvent) => void
-  resetOrder: () => void
-  sortBy: (criteria: 'created' | 'alphabetical' | 'category' | 'custom') => void
+  sortedTodos: Todo[];
+  handleDragEnd: (event: DragEndEvent) => void;
+  resetOrder: () => void;
+  sortBy: (
+    criteria: "created" | "alphabetical" | "category" | "custom",
+  ) => void;
 }
 
 export const useTodoSorting = (
   todos: Todo[],
-  onReorder?: (reorderedTodos: Todo[]) => void
+  onReorder?: (reorderedTodos: Todo[]) => void,
 ): UseTodoSortingReturn => {
   const sortedTodos = useMemo(() => {
-    return [...todos].sort((a, b) => a.order - b.order)
-  }, [todos])
+    return [...todos].sort((a, b) => a.order - b.order);
+  }, [todos]);
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
-      const { active, over } = event
+      const { active, over } = event;
 
       if (!over || active.id === over.id) {
-        return
+        return;
       }
 
-      const oldIndex = sortedTodos.findIndex(todo => todo.id === active.id)
-      const newIndex = sortedTodos.findIndex(todo => todo.id === over.id)
+      const oldIndex = sortedTodos.findIndex((todo) => todo.id === active.id);
+      const newIndex = sortedTodos.findIndex((todo) => todo.id === over.id);
 
       if (oldIndex === -1 || newIndex === -1) {
-        return
+        return;
       }
 
-      const reordered = arrayMove(sortedTodos, oldIndex, newIndex)
+      const reordered = arrayMove(sortedTodos, oldIndex, newIndex);
       const reorderedWithOrder = reordered.map((todo, index) => ({
         ...todo,
         order: index,
-      }))
+      }));
 
-      onReorder?.(reorderedWithOrder)
+      onReorder?.(reorderedWithOrder);
     },
-    [sortedTodos, onReorder]
-  )
+    [sortedTodos, onReorder],
+  );
 
   const resetOrder = useCallback(() => {
     const sorted = [...todos].sort(
-      (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
-    )
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+    );
     const reorderedWithOrder = sorted.map((todo, index) => ({
       ...todo,
       order: index,
-    }))
-    onReorder?.(reorderedWithOrder)
-  }, [todos, onReorder])
+    }));
+    onReorder?.(reorderedWithOrder);
+  }, [todos, onReorder]);
 
   const sortBy = useCallback(
-    (criteria: 'created' | 'alphabetical' | 'category' | 'custom') => {
-      let sorted: Todo[]
+    (criteria: "created" | "alphabetical" | "category" | "custom") => {
+      let sorted: Todo[];
 
       switch (criteria) {
-        case 'created':
+        case "created":
           sorted = [...todos].sort(
-            (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
-          )
-          break
-        case 'alphabetical':
-          sorted = [...todos].sort((a, b) => a.text.localeCompare(b.text))
-          break
-        case 'category':
+            (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+          );
+          break;
+        case "alphabetical":
+          sorted = [...todos].sort((a, b) => a.text.localeCompare(b.text));
+          break;
+        case "category":
           sorted = [...todos].sort((a, b) => {
-            const categoryA = a.categoryId || ''
-            const categoryB = b.categoryId || ''
-            return categoryA.localeCompare(categoryB)
-          })
-          break
-        case 'custom':
+            const categoryA = a.categoryId || "";
+            const categoryB = b.categoryId || "";
+            return categoryA.localeCompare(categoryB);
+          });
+          break;
+        case "custom":
         default:
-          sorted = [...todos].sort((a, b) => a.order - b.order)
-          break
+          sorted = [...todos].sort((a, b) => a.order - b.order);
+          break;
       }
 
       const reorderedWithOrder = sorted.map((todo, index) => ({
         ...todo,
         order: index,
-      }))
-      onReorder?.(reorderedWithOrder)
+      }));
+      onReorder?.(reorderedWithOrder);
     },
-    [todos, onReorder]
-  )
+    [todos, onReorder],
+  );
 
   return {
     sortedTodos,
     handleDragEnd,
     resetOrder,
     sortBy,
-  }
-}
+  };
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter
       future={{
@@ -14,5 +14,5 @@ createRoot(document.getElementById('root')!).render(
     >
       <App />
     </BrowserRouter>
-  </StrictMode>
-)
+  </StrictMode>,
+);

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -1,22 +1,22 @@
 export interface Category {
-  id: string
-  name: string
-  color: string
-  description?: string
-  createdAt: Date
-  updatedAt: Date
+  id: string;
+  name: string;
+  color: string;
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface CategoryFormData {
-  name: string
-  color: string
-  description?: string
+  name: string;
+  color: string;
+  description?: string;
 }
 
 export interface UseCategoryManagementReturn {
-  categories: Category[]
-  createCategory: (data: CategoryFormData) => void
-  updateCategory: (id: string, data: CategoryFormData) => void
-  deleteCategory: (id: string) => boolean
-  isCategoryInUse: (id: string) => boolean
+  categories: Category[];
+  createCategory: (data: CategoryFormData) => void;
+  updateCategory: (id: string, data: CategoryFormData) => void;
+  deleteCategory: (id: string) => boolean;
+  isCategoryInUse: (id: string) => boolean;
 }

--- a/frontend/src/types/filter.ts
+++ b/frontend/src/types/filter.ts
@@ -1,7 +1,7 @@
 export interface FilterState {
-  completionStatus: 'all' | 'completed' | 'incomplete'
-  categoryIds: string[]
-  tags: string[]
-  tagCondition: 'any' | 'all'
-  searchText: string
+  completionStatus: "all" | "completed" | "incomplete";
+  categoryIds: string[];
+  tags: string[];
+  tagCondition: "any" | "all";
+  searchText: string;
 }

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -1,15 +1,15 @@
 export interface Todo {
-  id: string
-  text: string
-  completed: boolean
-  createdAt: Date
-  categoryId?: string
-  tags: string[]
-  order: number
+  id: string;
+  text: string;
+  completed: boolean;
+  createdAt: Date;
+  categoryId?: string;
+  tags: string[];
+  order: number;
 }
 
 export interface EditTodoData {
-  text: string
-  categoryId?: string
-  tags: string[]
+  text: string;
+  categoryId?: string;
+  tags: string[];
 }

--- a/frontend/src/utils/filterLogic.ts
+++ b/frontend/src/utils/filterLogic.ts
@@ -1,67 +1,67 @@
-import type { Todo } from '../types/todo'
-import type { FilterState } from '../types/filter'
+import type { Todo } from "../types/todo";
+import type { FilterState } from "../types/filter";
 
 export const filterByCompletion = (
   todos: Todo[],
-  status: FilterState['completionStatus']
+  status: FilterState["completionStatus"],
 ): Todo[] => {
-  if (status === 'all') return todos
-  if (status === 'completed') return todos.filter(todo => todo.completed)
-  if (status === 'incomplete') return todos.filter(todo => !todo.completed)
-  return todos
-}
+  if (status === "all") return todos;
+  if (status === "completed") return todos.filter((todo) => todo.completed);
+  if (status === "incomplete") return todos.filter((todo) => !todo.completed);
+  return todos;
+};
 
 export const filterByCategories = (
   todos: Todo[],
-  categoryIds: string[]
+  categoryIds: string[],
 ): Todo[] => {
-  if (categoryIds.length === 0) return todos
-  return todos.filter(todo => categoryIds.includes(todo.categoryId || ''))
-}
+  if (categoryIds.length === 0) return todos;
+  return todos.filter((todo) => categoryIds.includes(todo.categoryId || ""));
+};
 
 export const filterByTags = (
   todos: Todo[],
   tags: string[],
-  condition: 'any' | 'all'
+  condition: "any" | "all",
 ): Todo[] => {
-  if (tags.length === 0) return todos
+  if (tags.length === 0) return todos;
 
-  return todos.filter(todo => {
-    if (condition === 'all') {
-      return tags.every(tag => todo.tags.includes(tag))
+  return todos.filter((todo) => {
+    if (condition === "all") {
+      return tags.every((tag) => todo.tags.includes(tag));
     } else {
-      return tags.some(tag => todo.tags.includes(tag))
+      return tags.some((tag) => todo.tags.includes(tag));
     }
-  })
-}
+  });
+};
 
 export const filterBySearch = (todos: Todo[], searchText: string): Todo[] => {
-  const trimmedSearch = searchText.trim()
-  if (trimmedSearch === '') return todos
+  const trimmedSearch = searchText.trim();
+  if (trimmedSearch === "") return todos;
 
-  return todos.filter(todo =>
-    todo.text.toLowerCase().includes(trimmedSearch.toLowerCase())
-  )
-}
+  return todos.filter((todo) =>
+    todo.text.toLowerCase().includes(trimmedSearch.toLowerCase()),
+  );
+};
 
 export const applyFilters = (todos: Todo[], filters: FilterState): Todo[] => {
-  let filtered = todos
+  let filtered = todos;
 
-  filtered = filterByCompletion(filtered, filters.completionStatus)
-  filtered = filterByCategories(filtered, filters.categoryIds)
-  filtered = filterByTags(filtered, filters.tags, filters.tagCondition)
-  filtered = filterBySearch(filtered, filters.searchText)
+  filtered = filterByCompletion(filtered, filters.completionStatus);
+  filtered = filterByCategories(filtered, filters.categoryIds);
+  filtered = filterByTags(filtered, filters.tags, filters.tagCondition);
+  filtered = filterBySearch(filtered, filters.searchText);
 
-  return filtered
-}
+  return filtered;
+};
 
 export const getActiveFilterCount = (filters: FilterState): number => {
-  let count = 0
+  let count = 0;
 
-  if (filters.completionStatus !== 'all') count++
-  if (filters.categoryIds.length > 0) count++
-  if (filters.tags.length > 0) count++
-  if (filters.searchText.trim() !== '') count++
+  if (filters.completionStatus !== "all") count++;
+  if (filters.categoryIds.length > 0) count++;
+  if (filters.tags.length > 0) count++;
+  if (filters.searchText.trim() !== "") count++;
 
-  return count
-}
+  return count;
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,18 +1,18 @@
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
-    environment: 'jsdom',
-    setupFiles: './__tests__/setup/setup.ts',
+    environment: "jsdom",
+    setupFiles: "./__tests__/setup/setup.ts",
     exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/.{idea,git,cache,output,temp}/**',
-      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*',
-      '**/__tests__/e2e/**', // E2Eテストを除外
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.{idea,git,cache,output,temp}/**",
+      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
+      "**/__tests__/e2e/**", // E2Eテストを除外
     ],
   },
-})
+});


### PR DESCRIPTION
## 概要
- フロントエンドのサービス名を`frontend`に統一（ドキュメント内の`app`表記を修正）
- テスト／Lint／Formatは新規コンテナを作らず、既存コンテナ上で`docker compose exec`実行へ変更
- 例・エイリアス・トラブルシューティングも上記方針に合わせて更新
- Prettierでフロントエンド全体を整形し、差分ノイズを軽減

## 変更詳細
- AGENTS.md / Docker.md / CLAUDE.md
  - `app`→`frontend`へ統一
  - Frontendテストは `docker compose exec frontend npm run test(:run)` に変更
  - ESLint/Prettierも `exec` 実行に統一
  - 再ビルド／ログ／再起動コマンド例も`frontend`へ合わせて修正
- リント／フォーマットの前提を整えるためにPrettierを全体適用
- 今後の運用忘れ防止のため、コミットメッセージ・PRは日本語で記載する旨をAGENTS.md/CLAUDE.mdへ追記

## 背景・目的
- 日常のテスト/Lint/Formatで新規コンテナを起動せず、ログが残る既存コンテナでの実行に統一するため
- ドキュメント内のサービス名不一致を解消して混乱を防ぐため
- 先行して整形を適用し、Issue #25の実装時にフォーマット差分のノイズを抑えるため

## 注意点
- 機能的なコード変更はありません（整形のみ）。
- CI/CDや開発端末のエイリアスも`exec`前提に更新しています。