### PR TITLE
feat(frontend): LocalStorageからAPI連携へ移行（Issue #25）

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -280,6 +280,18 @@ docker compose run --rm backend rails db:migrate RAILS_ENV=test
    
    # 単体テストを監視モードで実行（既存コンテナでexec）
    docker compose exec frontend npm run test
+
+   # ESLintをチェックモードで実行
+   docker compose exec frontend npm run lint
+
+   # ESLintを自動修正モードで実行
+   docker compose exec frontend npm run lint:fix
+
+   # Prettierによるコードフォーマット実行
+   docker compose exec frontend npm run format
+
+   # Prettierによるコードフォーマットチェック
+   docker compose exec frontend npm run format:check
    ```
 
 2. **バックエンド開発中の継続的テスト**:

--- a/frontend/__tests__/components/CategoriesPage.ux.test.tsx
+++ b/frontend/__tests__/components/CategoriesPage.ux.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { CategoriesPage } from "../../src/components/CategoriesPage";
+
+// 概要: CategoriesPageのUI/UX（ローディング/エラー/オフライン表示）をテスト
+// 目的: Issue #25 のUI/UX改善要件（スピナー、エラーメッセージ、オフライン警告）を保証
+
+const renderWithRouter = () =>
+  render(
+    <MemoryRouter
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <CategoriesPage />
+    </MemoryRouter>,
+  );
+
+// useCategoryManagementをモック
+vi.mock("../../src/hooks/useCategoryManagement", () => ({
+  useCategoryManagement: vi.fn(),
+}));
+
+describe("CategoriesPage UI/UX", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // 概要: ローディング中にスピナーが表示されることをテスト
+  // 目的: データ取得中のユーザー向けフィードバックを保証
+  it("shows loading spinner when loading is true", async () => {
+    const { useCategoryManagement } = vi.mocked(
+      await import("../../src/hooks/useCategoryManagement"),
+    );
+    useCategoryManagement.mockReturnValue({
+      categories: [],
+      createCategory: vi.fn(),
+      updateCategory: vi.fn(),
+      deleteCategory: vi.fn(),
+      isCategoryInUse: vi.fn(),
+      loading: true,
+    });
+
+    renderWithRouter();
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  // 概要: エラー発生時にエラーメッセージが表示されることをテスト
+  // 目的: API失敗時のユーザーへの分かりやすい通知を保証
+  it("shows error alert when error is set", async () => {
+    const { useCategoryManagement } = vi.mocked(
+      await import("../../src/hooks/useCategoryManagement"),
+    );
+    useCategoryManagement.mockReturnValue({
+      categories: [],
+      createCategory: vi.fn(),
+      updateCategory: vi.fn(),
+      deleteCategory: vi.fn(),
+      isCategoryInUse: vi.fn(),
+      error: "カテゴリの取得に失敗しました",
+    });
+
+    renderWithRouter();
+
+    expect(
+      screen.getByText("カテゴリの取得に失敗しました"),
+    ).toBeInTheDocument();
+  });
+
+  // 概要: オフライン時に警告が表示されることをテスト
+  // 目的: ネットワーク切断状態の明示的な可視化を保証
+  it("shows offline warning when offline flag is true", async () => {
+    const { useCategoryManagement } = vi.mocked(
+      await import("../../src/hooks/useCategoryManagement"),
+    );
+    useCategoryManagement.mockReturnValue({
+      categories: [],
+      createCategory: vi.fn(),
+      updateCategory: vi.fn(),
+      deleteCategory: vi.fn(),
+      isCategoryInUse: vi.fn(),
+      offline: true,
+    });
+
+    renderWithRouter();
+
+    expect(screen.getByText(/オフライン/)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/TodoApp.api.test.tsx
+++ b/frontend/__tests__/components/TodoApp.api.test.tsx
@@ -1,0 +1,128 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TodoApp } from "../../src/components/TodoApp";
+import type { Todo } from "../../src/types/todo";
+
+// 概要: APIモックを使ってTodoAppがAPI経由でデータ取得・作成・更新・削除することをテスト
+// 目的: LocalStorageからAPI連携への移行（Issue #25）の動作保証
+
+vi.mock("../../src/api/todos", () => {
+  return {
+    listTodos: vi.fn(),
+    createTodo: vi.fn(),
+    updateTodo: vi.fn(),
+    deleteTodo: vi.fn(),
+  };
+});
+
+import {
+  listTodos,
+  createTodo,
+  updateTodo,
+  deleteTodo,
+} from "../../src/api/todos";
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: "1",
+  text: "First",
+  completed: false,
+  createdAt: new Date("2025-08-30T10:00:00Z"),
+  categoryId: undefined,
+  tags: [],
+  order: 0,
+  ...overrides,
+});
+
+describe("TodoApp (API)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // 概要: 初期表示時にAPIからTodo一覧を取得して表示する
+  // 目的: listTodosが呼ばれ、結果がレンダリングされることを保証
+  it("fetches and renders todos on mount", async () => {
+    (listTodos as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      makeTodo({ id: "1", text: "API Todo" }),
+    ]);
+
+    render(<TodoApp />);
+
+    await waitFor(() => {
+      expect(screen.getByText("API Todo")).toBeInTheDocument();
+    });
+  });
+
+  // 概要: フォーム送信でcreateTodoが呼ばれ、UIに反映される
+  // 目的: 追加フローがAPI経由で動作することを保証
+  it("creates todo via API and renders it", async () => {
+    (listTodos as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      [],
+    );
+    (createTodo as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeTodo({ id: "10", text: "Created via API" }),
+    );
+
+    render(<TodoApp />);
+
+    const input = await screen.findByPlaceholderText("新しいタスクを入力");
+    fireEvent.change(input, { target: { value: "Created via API" } });
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Created via API")).toBeInTheDocument();
+    });
+  });
+
+  // 概要: チェックボックス操作でupdateTodoが呼ばれる
+  // 目的: 完了状態切替がAPI経由で行われることを保証（UIは楽観的更新）
+  it("toggles completion via API", async () => {
+    (listTodos as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      makeTodo({ id: "1", text: "Toggle", completed: false }),
+    ]);
+    (updateTodo as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeTodo({ id: "1", text: "Toggle", completed: true }),
+    );
+
+    render(<TodoApp />);
+    // 対象のTodo行に限定してチェックボックスを取得（FilterBar等のチェック系UIを回避）
+    const itemText = await screen.findByText("Toggle");
+    const listItem = itemText.closest("li") as HTMLElement;
+    const checkbox = within(listItem).getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(updateTodo).toHaveBeenCalled();
+    });
+  });
+
+  // 概要: 削除ボタンでdeleteTodoが呼ばれ、UIから消える
+  // 目的: 削除フローがAPI経由で動作することを保証
+  it("deletes todo via API", async () => {
+    (listTodos as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      makeTodo({ id: "1", text: "To Delete" }),
+    ]);
+    (deleteTodo as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      undefined,
+    );
+
+    render(<TodoApp />);
+
+    // 初期表示
+    await screen.findByText("To Delete");
+
+    // 削除
+    const deleteButton = screen.getByLabelText(/delete/i);
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(deleteTodo).toHaveBeenCalledWith("1");
+      expect(screen.queryByText("To Delete")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/__tests__/components/TodoApp.test.tsx
+++ b/frontend/__tests__/components/TodoApp.test.tsx
@@ -1,11 +1,50 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { TodoApp } from "../../src/components/TodoApp";
+import type { Todo } from "../../src/types/todo";
+
+vi.mock("../../src/api/todos", () => ({
+  listTodos: vi.fn(),
+  createTodo: vi.fn(),
+  updateTodo: vi.fn(),
+  deleteTodo: vi.fn(),
+}));
+
+import {
+  listTodos,
+  createTodo,
+  updateTodo,
+  deleteTodo,
+} from "../../src/api/todos";
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: String(Date.now()),
+  text: "Mock",
+  completed: false,
+  createdAt: new Date(),
+  categoryId: undefined,
+  tags: [],
+  order: 0,
+  ...overrides,
+});
 
 describe("TodoApp", () => {
   beforeEach(() => {
-    // 各テスト前にlocalStorageをクリア
-    localStorage.clear();
+    // APIモックの初期化
+    vi.resetAllMocks();
+    // フィルターなどの永続状態が他テストに干渉しないようクリア
+    window.localStorage.clear();
+    (listTodos as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (createTodo as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async ({ text, categoryId }: { text: string; categoryId?: string }) =>
+        makeTodo({ id: String(Date.now()), text, categoryId }),
+    );
+    (updateTodo as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeTodo(),
+    );
+    (deleteTodo as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      undefined,
+    );
   });
   // 概要: アプリケーションのタイトルが正しく表示されることを確認
   // 目的: UIの基本構造が正しくレンダリングされることを保証

--- a/frontend/__tests__/components/TodoApp.ux.test.tsx
+++ b/frontend/__tests__/components/TodoApp.ux.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { TodoApp } from "../../src/components/TodoApp";
+
+// 概要: Todo画面におけるオフライン検知と通知表示をテスト
+// 目的: ネットワーク切断時にユーザーへ明確な警告を表示することを保証
+
+describe("TodoApp UI/UX", () => {
+  beforeEach(() => {
+    // 既存のStorageやイベントを汚さない
+    window.localStorage.clear();
+  });
+
+  // 概要: navigator.onLine=false または offlineイベント時に警告が表示される
+  // 目的: 画面がオフライン状態を通知することを保証
+  it("shows offline alert when offline", async () => {
+    // onLineをfalseに見せる
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      get() {
+        return false;
+      },
+    });
+
+    render(<TodoApp />);
+
+    expect(screen.getByText(/オフライン/)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/e2e/category-management.spec.ts
+++ b/frontend/__tests__/e2e/category-management.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/test";
+import { setupApiMock } from "./utils/mockApi";
 
 test.describe("Category Management E2E Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMock(page);
+  });
   // 概要: ナビゲーション機能をテスト
   // 目的: Todo画面とカテゴリ管理画面間の遷移が正しく動作することを保証（Issue #5要件）
   test("should navigate between Todo and Category pages", async ({ page }) => {

--- a/frontend/__tests__/e2e/layout-consistency.spec.ts
+++ b/frontend/__tests__/e2e/layout-consistency.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/test";
+import { setupApiMock } from "./utils/mockApi";
 
 test.describe("Layout Consistency E2E Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMock(page);
+  });
   // 概要: ナビゲーション間でのレイアウト幅の一貫性をテスト
   // 目的: TodoページとCategoriesページ間でコンテンツ幅が一貫していることを保証
   test("should maintain consistent layout width across navigation", async ({

--- a/frontend/__tests__/e2e/navigation-theme.spec.ts
+++ b/frontend/__tests__/e2e/navigation-theme.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/test";
+import { setupApiMock } from "./utils/mockApi";
 
 test.describe("Navigation Theme E2E Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMock(page);
+  });
   // 概要: ライトモード時のナビゲーションタブ表示をテスト
   // 目的: 選択されたタブが白色で表示され、非選択タブも視認可能であることを保証
   test("should display navigation tabs with proper contrast in light mode", async ({

--- a/frontend/__tests__/e2e/todo-app.spec.ts
+++ b/frontend/__tests__/e2e/todo-app.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/test";
+import { setupApiMock } from "./utils/mockApi";
 
 test.describe("Todo App E2E Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMock(page);
+  });
   // 概要: ページが正しく読み込まれ、基本的なUI要素が表示されることを確認
   // 目的: アプリケーションの基本構造がブラウザで正しく動作することを保証
   test("should load the todo app with basic elements", async ({ page }) => {
@@ -39,16 +43,16 @@ test.describe("Todo App E2E Tests", () => {
     await input.fill("Test Todo");
     await addButton.click();
 
-    // Todo項目のcheckboxを特定（FilterBarのSwitchと区別）
-    const checkbox = page.getByRole("checkbox").last();
+    // Todo項目の行コンテナ内のcheckboxを明示的に取得（FilterBarのSwitchと区別）
+    const row = page.locator('li:has-text("Test Todo")').first();
+    const checkbox = row.locator('input[type="checkbox"]').first();
     await expect(checkbox).not.toBeChecked();
-
     await checkbox.click();
     await expect(checkbox).toBeChecked();
 
-    // 完了済みTodoのテキストに取り消し線が適用されることを確認
-    const todoText = page.getByText("Test Todo");
-    await expect(todoText).toHaveCSS("text-decoration", /line-through/);
+    // 完了済みTodoのテキストに取り消し線が適用されることを確認（該当行内のpを対象）
+    const textEl = row.locator("p");
+    await expect(textEl).toHaveCSS("text-decoration-line", "line-through");
   });
 
   // 概要: ユーザーがTodoを削除できることをE2Eで確認
@@ -122,7 +126,7 @@ test.describe("Todo App E2E Tests", () => {
     await page.goto("/");
 
     const input = page.getByPlaceholder("新しいタスクを入力");
-    const categorySelect = page.getByLabel("カテゴリ").first();
+    const categorySelect = page.getByTestId("todoform-category");
     const addButton = page.getByRole("button", { name: "追加" });
 
     await input.fill("仕事のタスク");
@@ -140,7 +144,7 @@ test.describe("Todo App E2E Tests", () => {
     await page.goto("/");
 
     const input = page.getByPlaceholder("新しいタスクを入力");
-    const tagInput = page.getByLabel("タグ").first();
+    const tagInput = page.getByTestId("todoform-tags");
     const addButton = page.getByRole("button", { name: "追加" });
 
     await input.fill("タグ付きタスク");
@@ -521,7 +525,7 @@ test.describe("Todo App E2E Tests", () => {
     await editButton.click();
 
     // カテゴリセレクトが編集フォームに表示されることを確認
-    const editCategorySelect = page.getByLabel("カテゴリ").last();
+    const editCategorySelect = page.getByTestId("todoedit-category");
     await expect(editCategorySelect).toBeVisible();
 
     // カテゴリを変更
@@ -529,7 +533,7 @@ test.describe("Todo App E2E Tests", () => {
     await page.getByText("プライベート").click();
 
     // テキストも変更
-    const editInput = page.locator("textarea").first();
+    const editInput = page.getByTestId("todoedit-text");
     await expect(editInput).toHaveValue("Category Todo");
     await editInput.fill("Updated Category Todo");
 
@@ -562,7 +566,7 @@ test.describe("Todo App E2E Tests", () => {
     await editButton.click();
 
     // タグ入力フィールドが編集フォームに表示されることを確認
-    const editTagInput = page.getByLabel("タグ").last(); // 編集フォーム内のタグ入力
+    const editTagInput = page.getByTestId("todoedit-tags"); // 編集フォーム内のタグ入力
     await expect(editTagInput).toBeVisible();
     await expect(editTagInput).toHaveValue("初期タグ1, 初期タグ2");
 
@@ -570,7 +574,7 @@ test.describe("Todo App E2E Tests", () => {
     await editTagInput.fill("更新タグ1, 更新タグ2, 新タグ");
 
     // テキストも変更
-    const editTextInput = page.locator("textarea").first(); // テキスト用の入力フィールド（1番目）
+    const editTextInput = page.getByTestId("todoedit-text"); // テキスト用の入力フィールド
     await expect(editTextInput).toHaveValue("Tagged Todo");
     await editTextInput.fill("Updated Tagged Todo");
 

--- a/frontend/__tests__/e2e/ui-ux.spec.ts
+++ b/frontend/__tests__/e2e/ui-ux.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+
+// 概要: UI/UX改善（ローディング・エラー・オフライン）をE2Eで確認
+// 目的: 実ブラウザ環境でユーザー体験が満たされていることを保証
+
+// 概要: Todoトップでオフライン時に警告が表示される
+// 目的: オンライン→オフラインの遷移で警告が出ることを保証
+test("todo page shows offline warning when going offline", async ({ page }) => {
+  await page.goto("/");
+
+  await page.context().setOffline(true);
+  await page.evaluate(() => window.dispatchEvent(new Event("offline")));
+
+  await expect(page.getByText(/オフライン/)).toBeVisible();
+
+  await page.context().setOffline(false);
+  await page.evaluate(() => window.dispatchEvent(new Event("online")));
+});
+
+// 概要: カテゴリ一覧ページでオフライン時に警告が表示される
+// 目的: 画面遷移後のオフライン検知も機能することを保証
+test("categories page shows offline warning when going offline", async ({
+  page,
+}) => {
+  await page.goto("/categories");
+
+  await page.context().setOffline(true);
+  await page.evaluate(() => window.dispatchEvent(new Event("offline")));
+
+  await expect(page.getByTestId("categories-offline")).toBeVisible();
+
+  await page.context().setOffline(false);
+  await page.evaluate(() => window.dispatchEvent(new Event("online")));
+});
+
+// 概要: カテゴリ一覧の取得が失敗した場合、エラーメッセージが表示される
+// 目的: APIエラー時にユーザーへ適切に通知されることを保証
+test("categories page shows error alert when API fails", async ({
+  page,
+  context,
+}) => {
+  // 絶対URLパターンで事前にルート登録（ナビゲーション前）
+  await context.route(
+    /https?:\/\/localhost:3001\/api\/categories(\?.*)?$/,
+    async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ errors: [{ message: "backend error" }] }),
+      });
+    },
+  );
+
+  await page.goto("/categories");
+  await expect(page.getByTestId("categories-error")).toBeVisible({
+    timeout: 10000,
+  });
+});
+
+// 概要: カテゴリ一覧取得中はローディングスピナーが表示される
+// 目的: データ取得中のフィードバックを保証
+test("categories page shows loading spinner while fetching", async ({
+  page,
+  context,
+}) => {
+  // 絶対URLパターンで事前にルート登録（ナビゲーション前）
+  await context.route(
+    /https?:\/\/localhost:3001\/api\/categories(\?.*)?$/,
+    async (route) => {
+      // 人工遅延でloadingを可視化
+      await new Promise((r) => setTimeout(r, 700));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      });
+    },
+  );
+
+  await page.goto("/categories");
+  // API応答遅延中にローディングが表示される
+  await expect(page.getByTestId("categories-loading")).toBeVisible({
+    timeout: 10000,
+  });
+  // 念のためローディング解除まで待機
+  await expect(page.getByTestId("categories-loading")).toBeHidden({
+    timeout: 10000,
+  });
+});

--- a/frontend/__tests__/e2e/utils/mockApi.ts
+++ b/frontend/__tests__/e2e/utils/mockApi.ts
@@ -1,0 +1,159 @@
+import type { Page, Route } from "@playwright/test";
+
+type Todo = {
+  id: string;
+  text: string;
+  completed: boolean;
+  category_id?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type Category = {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function setupApiMock(page: Page) {
+  // 各テスト開始時に永続状態をクリア（フィルター等のローカルストレージ汚染を防ぐ）
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.clear();
+      sessionStorage.clear();
+    } catch {
+      // intentionally ignore storage clearing errors
+      return;
+    }
+  });
+  // テスト毎にクリーンなインメモリDB
+  let todos: Todo[] = [];
+  let categories: Category[] = [
+    {
+      id: "work",
+      name: "仕事",
+      created_at: new Date("2024-01-01").toISOString(),
+      updated_at: new Date("2024-01-01").toISOString(),
+    },
+    {
+      id: "private",
+      name: "プライベート",
+      created_at: new Date("2024-01-02").toISOString(),
+      updated_at: new Date("2024-01-02").toISOString(),
+    },
+    {
+      id: "other",
+      name: "その他",
+      created_at: new Date("2024-01-03").toISOString(),
+      updated_at: new Date("2024-01-03").toISOString(),
+    },
+  ];
+
+  async function handleApi(route: Route) {
+    const req = route.request();
+    const url = new URL(req.url());
+    const { pathname } = url;
+    const method = req.method();
+
+    // Categories
+    if (pathname === "/api/categories" && method === "GET") {
+      return route.fulfill({ json: { data: categories } });
+    }
+    if (pathname === "/api/categories" && method === "POST") {
+      const body = (await req.postDataJSON()) as { name: string };
+      const now = new Date().toISOString();
+      const id = String(Date.now());
+      const entity: Category = {
+        id,
+        name: body.name,
+        created_at: now,
+        updated_at: now,
+      };
+      categories = [...categories, entity];
+      return route.fulfill({ status: 201, json: { data: entity } });
+    }
+    const catMatch = pathname.match(/^\/api\/categories\/(.+)$/);
+    if (catMatch) {
+      const id = catMatch[1];
+      if (method === "PATCH") {
+        const body = (await req.postDataJSON()) as { name?: string };
+        categories = categories.map((c) =>
+          c.id === id
+            ? {
+                ...c,
+                name: body.name ?? c.name,
+                updated_at: new Date().toISOString(),
+              }
+            : c,
+        );
+        const entity = categories.find((c) => c.id === id)!;
+        return route.fulfill({ json: { data: entity } });
+      }
+      if (method === "DELETE") {
+        categories = categories.filter((c) => c.id !== id);
+        return route.fulfill({ status: 204, body: "" });
+      }
+    }
+
+    // Todos
+    if (pathname === "/api/todos" && method === "GET") {
+      return route.fulfill({ json: { data: todos } });
+    }
+    if (pathname === "/api/todos" && method === "POST") {
+      const body = (await req.postDataJSON()) as {
+        text: string;
+        category_id?: string;
+        completed?: boolean;
+      };
+      const now = new Date().toISOString();
+      const id = String(Date.now());
+      const entity: Todo = {
+        id,
+        text: body.text,
+        completed: !!body.completed,
+        category_id: body.category_id ?? null,
+        created_at: now,
+        updated_at: now,
+      };
+      todos = [...todos, entity];
+      return route.fulfill({ status: 201, json: { data: entity } });
+    }
+    const todoMatch = pathname.match(/^\/api\/todos\/(.+)$/);
+    if (todoMatch) {
+      const id = todoMatch[1];
+      if (method === "PATCH") {
+        const body = (await req.postDataJSON()) as {
+          text?: string;
+          completed?: boolean;
+          category_id?: string;
+        };
+        todos = todos.map((t) =>
+          t.id === id
+            ? {
+                ...t,
+                text: body.text ?? t.text,
+                completed:
+                  typeof body.completed === "boolean"
+                    ? body.completed
+                    : t.completed,
+                category_id: body.category_id ?? t.category_id,
+                updated_at: new Date().toISOString(),
+              }
+            : t,
+        );
+        const entity = todos.find((t) => t.id === id)!;
+        return route.fulfill({ json: { data: entity } });
+      }
+      if (method === "DELETE") {
+        todos = todos.filter((t) => t.id !== id);
+        return route.fulfill({ status: 204, body: "" });
+      }
+    }
+
+    // それ以外は素通し
+    return route.fallback();
+  }
+
+  await page.route("**/api/**", handleApi);
+}

--- a/frontend/__tests__/hooks/useCategoryManagement.test.ts
+++ b/frontend/__tests__/hooks/useCategoryManagement.test.ts
@@ -1,57 +1,67 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useCategoryManagement } from "../../src/hooks/useCategoryManagement";
 import type { CategoryFormData } from "../../src/types/category";
 
-// useLocalStorageをモック
-vi.mock("../../src/hooks/useLocalStorage", () => ({
-  useLocalStorage: vi.fn(),
+// Category APIをモック
+vi.mock("../../src/api/categories", () => ({
+  listCategories: vi.fn(),
+  createCategory: vi.fn(),
+  updateCategory: vi.fn(),
+  deleteCategory: vi.fn(),
 }));
 
 describe("useCategoryManagement", () => {
-  const mockSetCategories = vi.fn();
-
   beforeEach(async () => {
     vi.clearAllMocks();
-    const mockUseLocalStorage = vi.mocked(
-      await import("../../src/hooks/useLocalStorage"),
-    ).useLocalStorage;
-    mockUseLocalStorage.mockReturnValue([
-      [
-        {
-          id: "work",
-          name: "仕事",
-          color: "#1976d2",
-          description: "仕事関連のタスク",
-          createdAt: new Date("2024-01-01"),
-          updatedAt: new Date("2024-01-01"),
-        },
-        {
-          id: "private",
-          name: "プライベート",
-          color: "#ff5722",
-          description: "個人的なタスク",
-          createdAt: new Date("2024-01-02"),
-          updatedAt: new Date("2024-01-02"),
-        },
-      ],
-      mockSetCategories,
+    const cats = await import("../../src/api/categories");
+    (
+      cats.listCategories as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([
+      {
+        id: "work",
+        name: "仕事",
+        color: "#1976d2",
+        description: "仕事関連のタスク",
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      },
+      {
+        id: "private",
+        name: "プライベート",
+        color: "#ff5722",
+        description: "個人的なタスク",
+        createdAt: new Date("2024-01-02"),
+        updatedAt: new Date("2024-01-02"),
+      },
     ]);
+    (
+      cats.createCategory as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(async ({ name }: { name: string }) => ({
+      id: `new-${Date.now()}`,
+      name,
+      color: "#1976d2",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
   });
 
   // 概要: useCategoryManagementフックの初期状態をテスト
   // 目的: カテゴリ一覧が正しく取得できることを保証
-  it("初期状態でカテゴリ一覧を返す", () => {
+  it("初期状態でカテゴリ一覧をAPIから取得して返す", async () => {
     const { result } = renderHook(() => useCategoryManagement());
 
-    expect(result.current.categories).toHaveLength(2);
-    expect(result.current.categories[0].name).toBe("仕事");
-    expect(result.current.categories[1].name).toBe("プライベート");
+    await waitFor(() => {
+      const names = result.current.categories.map((c) => c.name);
+      expect(names).toEqual(expect.arrayContaining(["仕事", "プライベート"]));
+      // APIモックが反映されていること（最終件数は2件）
+      expect(result.current.categories.length).toBe(2);
+    });
   });
 
   // 概要: createCategory機能をテスト
   // 目的: 新規カテゴリが正しく作成・追加されることを保証
-  it("新規カテゴリを作成できる", () => {
+  it("新規カテゴリを作成できる", async () => {
     const { result } = renderHook(() => useCategoryManagement());
 
     const newCategoryData: CategoryFormData = {
@@ -64,12 +74,69 @@ describe("useCategoryManagement", () => {
       result.current.createCategory(newCategoryData);
     });
 
-    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function));
+    await waitFor(() => {
+      expect(
+        result.current.categories.some((c) => c.name === "学習"),
+      ).toBeTruthy();
+    });
+  });
+
+  // 概要: 新規カテゴリ作成時にUIへ即時反映（楽観的更新）されることをテスト
+  // 目的: ユーザーの体感を改善し、API応答待ちの間も結果が見えることを保証
+  it("新規カテゴリは楽観的に即時表示される", async () => {
+    const { result } = renderHook(() => useCategoryManagement());
+
+    const optimisticData: CategoryFormData = {
+      name: "楽観カテゴリ",
+      color: "#123456",
+      description: "optimistic",
+    };
+
+    act(() => {
+      result.current.createCategory(optimisticData);
+    });
+
+    // API応答前でも即時に反映されること
+    const namesNow = result.current.categories.map((c) => c.name);
+    expect(namesNow).toEqual(expect.arrayContaining(["楽観カテゴリ"]));
+  });
+
+  // 概要: 作成APIが失敗した場合、楽観的に追加されたカテゴリがロールバックされることをテスト
+  // 目的: エラーパスでUI不整合が残らないことを保証
+  it("作成失敗時は楽観的追加がロールバックされる", async () => {
+    const cats = await import("../../src/api/categories");
+    (
+      cats.createCategory as unknown as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("fail"));
+
+    const { result } = renderHook(() => useCategoryManagement());
+
+    const data: CategoryFormData = {
+      name: "一時カテゴリ",
+      color: "#abcdef",
+      description: "temp",
+    };
+
+    act(() => {
+      result.current.createCategory(data);
+    });
+
+    // 直後は追加されている
+    expect(
+      result.current.categories.some((c) => c.name === "一時カテゴリ"),
+    ).toBe(true);
+
+    // 失敗後にロールバックされる
+    await waitFor(() => {
+      expect(
+        result.current.categories.some((c) => c.name === "一時カテゴリ"),
+      ).toBe(false);
+    });
   });
 
   // 概要: カテゴリ名の重複チェック機能をテスト
   // 目的: 同名カテゴリの作成を防止することを保証
-  it("同名のカテゴリ作成時は重複チェックする", () => {
+  it("同名のカテゴリ作成時は重複チェックする", async () => {
     const { result } = renderHook(() => useCategoryManagement());
 
     const duplicateData: CategoryFormData = {
@@ -81,13 +148,15 @@ describe("useCategoryManagement", () => {
       result.current.createCategory(duplicateData);
     });
 
-    // 重複する場合は何も追加されない
-    expect(mockSetCategories).not.toHaveBeenCalled();
+    await waitFor(() => {
+      const dupes = result.current.categories.filter((c) => c.name === "仕事");
+      expect(dupes.length).toBe(1);
+    });
   });
 
   // 概要: updateCategory機能をテスト
   // 目的: 既存カテゴリの情報が正しく更新されることを保証
-  it("カテゴリを更新できる", () => {
+  it("カテゴリを更新できる", async () => {
     const { result } = renderHook(() => useCategoryManagement());
 
     const updateData: CategoryFormData = {
@@ -100,7 +169,11 @@ describe("useCategoryManagement", () => {
       result.current.updateCategory("work", updateData);
     });
 
-    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function));
+    await waitFor(() => {
+      const updated = result.current.categories.find((c) => c.id === "work");
+      expect(updated?.name).toBe("仕事（重要）");
+      expect(updated?.color).toBe("#e91e63");
+    });
   });
 
   // 概要: isCategoryInUse機能をテスト
@@ -121,18 +194,23 @@ describe("useCategoryManagement", () => {
     const deleteResult = result.current.deleteCategory("work");
 
     expect(deleteResult).toBe(false);
-    expect(mockSetCategories).not.toHaveBeenCalled();
+    // 楽観的更新抑止のため、削除されていないことを確認
+    expect(result.current.categories.some((c) => c.id === "work")).toBe(true);
   });
 
   // 概要: 未使用カテゴリの削除機能をテスト
   // 目的: 未使用カテゴリが正しく削除されることを保証
-  it("未使用のカテゴリは削除できる", () => {
+  it("未使用のカテゴリは削除できる", async () => {
     const { result } = renderHook(() => useCategoryManagement());
 
     const deleteResult = result.current.deleteCategory("private");
 
     expect(deleteResult).toBe(true);
-    expect(mockSetCategories).toHaveBeenCalledWith(expect.any(Function));
+    await waitFor(() => {
+      expect(result.current.categories.some((c) => c.id === "private")).toBe(
+        false,
+      );
+    });
   });
 
   // 概要: 存在しないカテゴリの削除処理をテスト
@@ -143,6 +221,6 @@ describe("useCategoryManagement", () => {
     const deleteResult = result.current.deleteCategory("nonexistent");
 
     expect(deleteResult).toBe(false);
-    expect(mockSetCategories).not.toHaveBeenCalled();
+    expect(result.current.categories.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/__tests__/utils/apiClient.test.ts
+++ b/frontend/__tests__/utils/apiClient.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createApiClient } from "../../src/api/client";
+
+// 概要: APIクライアントの基本動作（GET/POST・エラーハンドリング）をテスト
+// 目的: Issue #25 の「API通信基盤」要件（baseURL, JSON処理, エラー処理）を最小限で担保
+
+const BASE_URL = "http://localhost:3001/api";
+
+// fetch のモック
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("api client", () => {
+  // 概要: GETがbaseURLに対して正しいパスでリクエストされ、JSONが返ることをテスト
+  // 目的: 基本的なGET通信の成功パスを保証
+  it("GET: 正しいURLにリクエストし、JSONを返す", async () => {
+    const api = createApiClient(BASE_URL);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: 1, text: "A" }] }),
+    } as unknown as Response);
+
+    const res = await api.get("/todos");
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/todos`,
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(res).toEqual({ data: [{ id: 1, text: "A" }] });
+  });
+
+  // 概要: POSTがJSONボディと適切なヘッダーで送信されることをテスト
+  // 目的: 作成・更新系の基本ヘッダーとボディシリアライズを保証
+  it("POST: JSONヘッダーとボディで送信する", async () => {
+    const api = createApiClient(BASE_URL);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ data: { id: 10, text: "B" } }),
+    } as unknown as Response);
+
+    const payload = { text: "B" };
+    const res = await api.post<{ data: { id: number; text: string } }>(
+      "/todos",
+      payload,
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/todos`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify(payload),
+      }),
+    );
+    expect(res.data.id).toBe(10);
+  });
+
+  // 概要: 4xx/5xx時にエラーメッセージとステータスを含む例外を投げることをテスト
+  // 目的: エラーハンドリングの最小仕様（Issue #25の要件）を担保
+  it("エラー応答: ステータスとメッセージを含む例外を投げる", async () => {
+    const api = createApiClient(BASE_URL);
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: async () => ({ errors: [{ message: "validation failed" }] }),
+    } as unknown as Response);
+
+    await expect(api.get("/todos")).rejects.toMatchObject({
+      status: 422,
+      message: expect.stringContaining("validation failed"),
+    });
+  });
+
+  // 概要: ネットワークエラー時に識別可能な例外を投げることをテスト
+  // 目的: オフライン検知・再試行UIに活用できるようエラー種別を付与
+  it("ネットワークエラー: typeが'network'の例外を投げる", async () => {
+    const api = createApiClient(BASE_URL);
+    fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    await expect(api.get("/todos")).rejects.toMatchObject({
+      type: "network",
+    });
+  });
+});

--- a/frontend/__tests__/utils/categoriesApi.test.ts
+++ b/frontend/__tests__/utils/categoriesApi.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  listCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from "../../src/api/categories";
+
+// 概要: Category APIラッパーの基本操作（一覧/作成/更新/削除）をテスト
+// 目的: Issue #25 のCategory機能API化に向けたI/Fと変換（snake->camel, Date変換）を保証
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("categories api", () => {
+  // 概要: GET /categories のレスポンスをCategory[]に変換する
+  // 目的: created_at/updated_atをDateへ変換し、id/nameを取り出す
+  it("lists categories and maps fields", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: 1,
+            name: "仕事",
+            created_at: "2025-08-30T10:00:00Z",
+            updated_at: "2025-08-30T10:00:00Z",
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    const categories = await listCategories();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/api/categories",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(categories).toHaveLength(1);
+    expect(categories[0].id).toBe("1");
+    expect(categories[0].name).toBe("仕事");
+    expect(categories[0].createdAt).toBeInstanceOf(Date);
+  });
+
+  // 概要: POST /categories の作成が正しいペイロードで送られ、変換後のCategoryが返る
+  // 目的: JSONヘッダー/ボディ、snake->camel 変換を保証
+  it("creates category and returns mapped entity", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        data: {
+          id: 10,
+          name: "学習",
+          created_at: "2025-08-30T10:00:00Z",
+          updated_at: "2025-08-30T10:00:00Z",
+        },
+      }),
+    } as unknown as Response);
+
+    const cat = await createCategory({ name: "学習" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/api/categories",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ name: "学習" }),
+      }),
+    );
+    expect(cat.id).toBe("10");
+    expect(cat.name).toBe("学習");
+  });
+
+  // 概要: PATCH /categories/:id の更新が正しく送信され、変換後のCategoryが返る
+  // 目的: name変更の送受信を保証
+  it("updates category and returns mapped entity", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          id: 10,
+          name: "重要な学習",
+          created_at: "2025-08-30T10:00:00Z",
+          updated_at: "2025-08-31T10:00:00Z",
+        },
+      }),
+    } as unknown as Response);
+
+    const cat = await updateCategory("10", { name: "重要な学習" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/api/categories/10",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+    expect(cat.name).toBe("重要な学習");
+  });
+
+  // 概要: DELETE /categories/:id の削除が200/204で成功する
+  // 目的: エラーを投げずに完了することを保証
+  it("deletes category", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+    } as unknown as Response);
+    await expect(deleteCategory("10")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/api/categories/10",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/frontend/__tests__/utils/todosApi.test.ts
+++ b/frontend/__tests__/utils/todosApi.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  listTodos,
+  createTodo,
+  updateTodo,
+  deleteTodo,
+} from "../../src/api/todos";
+
+// 概要: Todo APIラッパーの基本操作（一覧/作成/更新/削除）をテスト
+// 目的: Issue #25 のTodo機能API化に向けたI/Fと変換（snake->camel, Date変換, デフォルト値）を保証
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("todos api", () => {
+  // 概要: GET /todos のレスポンスをTodo[]に変換する
+  // 目的: created_at/updated_atをDateへ、category_idをcategoryIdへ、tagsのデフォルト付与
+  it("lists todos and maps fields", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: 1,
+            text: "A",
+            completed: false,
+            category_id: 2,
+            created_at: "2025-08-30T10:00:00Z",
+            updated_at: "2025-08-30T10:00:00Z",
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    const todos = await listTodos();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/api/todos",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(todos).toHaveLength(1);
+    expect(todos[0].id).toBe("1");
+    expect(todos[0].categoryId).toBe("2");
+    expect(Array.isArray(todos[0].tags)).toBe(true);
+    expect(todos[0].createdAt).toBeInstanceOf(Date);
+  });
+
+  // 概要: POST /todos の作成が正しいペイロードで送られ、変換後のTodoが返る
+  // 目的: JSONヘッダー/ボディ、snake->camel 変換を保証
+  it("creates todo and returns mapped entity", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        data: {
+          id: 10,
+          text: "B",
+          completed: false,
+          category_id: 2,
+          created_at: "2025-08-30T10:00:00Z",
+          updated_at: "2025-08-30T10:00:00Z",
+        },
+      }),
+    } as unknown as Response);
+
+    const todo = await createTodo({ text: "B", categoryId: "2" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/api/todos",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ text: "B", category_id: "2" }),
+      }),
+    );
+    expect(todo.id).toBe("10");
+    expect(todo.categoryId).toBe("2");
+  });
+
+  // 概要: PATCH /todos/:id の更新が正しく送信され、変換後のTodoが返る
+  // 目的: completed切替やtext変更の送受信を保証
+  it("updates todo and returns mapped entity", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          id: 10,
+          text: "C",
+          completed: true,
+          category_id: 2,
+          created_at: "2025-08-30T10:00:00Z",
+          updated_at: "2025-08-31T10:00:00Z",
+        },
+      }),
+    } as unknown as Response);
+
+    const todo = await updateTodo("10", { text: "C", completed: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/api/todos/10",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+    expect(todo.text).toBe("C");
+    expect(todo.completed).toBe(true);
+  });
+
+  // 概要: DELETE /todos/:id の削除が200/204で成功する
+  // 目的: エラーを投げずに完了することを保証
+  it("deletes todo", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+    } as unknown as Response);
+    await expect(deleteTodo("10")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/api/todos/10",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/frontend/src/api/categories.ts
+++ b/frontend/src/api/categories.ts
@@ -1,0 +1,52 @@
+import { api } from "./client";
+import type { Category } from "../types/category";
+
+type ApiCategory = {
+  id: number | string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type IndexResponse = { data: ApiCategory[] };
+type EntityResponse = { data: ApiCategory };
+
+function toCategory(entity: ApiCategory): Category {
+  return {
+    id: String(entity.id),
+    name: entity.name,
+    // バックエンドでは color/description をまだ返さないため適当なデフォルト値を設定
+    color: "#1976d2",
+    description: undefined,
+    createdAt: new Date(entity.created_at),
+    updatedAt: new Date(entity.updated_at),
+  };
+}
+
+export async function listCategories(): Promise<Category[]> {
+  const res = await api.get<IndexResponse>("/categories");
+  return res.data.map(toCategory);
+}
+
+export async function createCategory(payload: {
+  name: string;
+}): Promise<Category> {
+  const res = await api.post<EntityResponse>("/categories", {
+    name: payload.name,
+  });
+  return toCategory(res.data);
+}
+
+export async function updateCategory(
+  id: string,
+  payload: { name: string },
+): Promise<Category> {
+  const res = await api.patch<EntityResponse>(`/categories/${id}`, {
+    name: payload.name,
+  });
+  return toCategory(res.data);
+}
+
+export async function deleteCategory(id: string): Promise<void> {
+  await api.delete(`/categories/${id}`);
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,191 @@
+export type ApiError = {
+  status?: number;
+  message: string;
+  type?: "network" | "http" | "unknown";
+  details?: unknown;
+};
+
+type RequestOptions = {
+  headers?: Record<string, string>;
+};
+
+const defaultHeaders = {
+  "Content-Type": "application/json",
+};
+
+function buildUrl(baseURL: string, path: string) {
+  return `${baseURL.replace(/\/$/, "")}${path.startsWith("/") ? "" : "/"}${path}`;
+}
+
+async function parseJsonSafe(res: Response) {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+function isApiError(value: unknown): value is ApiError {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  const hasMessage = typeof v.message === "string";
+  const hasStatus = typeof v.status === "number";
+  const hasValidType =
+    typeof v.type === "string" &&
+    (v.type === "network" || v.type === "http" || v.type === "unknown");
+  // ApiError と判定するには、最低でも message と (status または type) を持つ必要がある
+  return hasMessage && (hasStatus || hasValidType);
+}
+
+export function createApiClient(baseURL: string) {
+  return {
+    async get<T = unknown>(
+      path: string,
+      options: RequestOptions = {},
+    ): Promise<T> {
+      try {
+        const res = await fetch(buildUrl(baseURL, path), {
+          method: "GET",
+          headers: { ...defaultHeaders, ...options.headers },
+        });
+        if (!res.ok) {
+          const body = await parseJsonSafe(res);
+          const message =
+            body?.errors?.[0]?.message || res.statusText || "Request failed";
+          const err: ApiError = {
+            status: res.status,
+            message,
+            type: "http",
+            details: body,
+          };
+          throw err;
+        }
+        return (await res.json()) as T;
+      } catch (e: unknown) {
+        if (isApiError(e)) throw e;
+        if (e instanceof TypeError) {
+          const err: ApiError = { type: "network", message: e.message };
+          throw err;
+        }
+        const err: ApiError = {
+          type: "unknown",
+          message: e instanceof Error ? e.message : "Unknown error",
+        };
+        throw err;
+      }
+    },
+
+    async post<T = unknown>(
+      path: string,
+      body?: unknown,
+      options: RequestOptions = {},
+    ): Promise<T> {
+      try {
+        const res = await fetch(buildUrl(baseURL, path), {
+          method: "POST",
+          headers: { ...defaultHeaders, ...options.headers },
+          body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+        if (!res.ok) {
+          const data = await parseJsonSafe(res);
+          const message =
+            data?.errors?.[0]?.message || res.statusText || "Request failed";
+          const err: ApiError = {
+            status: res.status,
+            message,
+            type: "http",
+            details: data,
+          };
+          throw err;
+        }
+        return (await res.json()) as T;
+      } catch (e: unknown) {
+        if (isApiError(e)) throw e;
+        if (e instanceof TypeError) {
+          const err: ApiError = { type: "network", message: e.message };
+          throw err;
+        }
+        const err: ApiError = {
+          type: "unknown",
+          message: e instanceof Error ? e.message : "Unknown error",
+        };
+        throw err;
+      }
+    },
+
+    async patch<T = unknown>(
+      path: string,
+      body?: unknown,
+      options: RequestOptions = {},
+    ): Promise<T> {
+      try {
+        const res = await fetch(buildUrl(baseURL, path), {
+          method: "PATCH",
+          headers: { ...defaultHeaders, ...options.headers },
+          body: body !== undefined ? JSON.stringify(body) : undefined,
+        });
+        if (!res.ok) {
+          const data = await parseJsonSafe(res);
+          const message =
+            data?.errors?.[0]?.message || res.statusText || "Request failed";
+          const err: ApiError = {
+            status: res.status,
+            message,
+            type: "http",
+            details: data,
+          };
+          throw err;
+        }
+        return (await res.json()) as T;
+      } catch (e: unknown) {
+        if (isApiError(e)) throw e;
+        if (e instanceof TypeError) {
+          const err: ApiError = { type: "network", message: e.message };
+          throw err;
+        }
+        const err: ApiError = {
+          type: "unknown",
+          message: e instanceof Error ? e.message : "Unknown error",
+        };
+        throw err;
+      }
+    },
+
+    async delete(path: string, options: RequestOptions = {}): Promise<void> {
+      try {
+        const res = await fetch(buildUrl(baseURL, path), {
+          method: "DELETE",
+          headers: { ...defaultHeaders, ...options.headers },
+        });
+        if (!res.ok) {
+          const data = await parseJsonSafe(res);
+          const message =
+            data?.errors?.[0]?.message || res.statusText || "Request failed";
+          const err: ApiError = {
+            status: res.status,
+            message,
+            type: "http",
+            details: data,
+          };
+          throw err;
+        }
+        return;
+      } catch (e: unknown) {
+        if (isApiError(e)) throw e;
+        if (e instanceof TypeError) {
+          const err: ApiError = { type: "network", message: e.message };
+          throw err;
+        }
+        const err: ApiError = {
+          type: "unknown",
+          message: e instanceof Error ? e.message : "Unknown error",
+        };
+        throw err;
+      }
+    },
+  };
+}
+
+const defaultBase =
+  import.meta.env?.VITE_API_BASE_URL || "http://localhost:3001/api";
+export const api = createApiClient(defaultBase);

--- a/frontend/src/api/todos.ts
+++ b/frontend/src/api/todos.ts
@@ -1,0 +1,65 @@
+import { api } from "./client";
+import type { Todo } from "../types/todo";
+
+type ApiTodo = {
+  id: number | string;
+  text: string;
+  completed: boolean;
+  category_id?: number | string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type IndexResponse = { data: ApiTodo[] };
+type EntityResponse = { data: ApiTodo };
+
+function toTodo(entity: ApiTodo): Todo {
+  return {
+    id: String(entity.id),
+    text: entity.text,
+    completed: entity.completed,
+    createdAt: new Date(entity.created_at),
+    categoryId:
+      entity.category_id === null || entity.category_id === undefined
+        ? undefined
+        : String(entity.category_id),
+    tags: [],
+    // APIからは順序情報を受け取らないため、呼び出し側で再計算想定
+    order: undefined,
+  };
+}
+
+export async function listTodos(): Promise<Todo[]> {
+  const res = await api.get<IndexResponse>("/todos");
+  return res.data.map(toTodo);
+}
+
+export async function createTodo(payload: {
+  text: string;
+  categoryId?: string;
+  completed?: boolean;
+}): Promise<Todo> {
+  const body: Record<string, unknown> = { text: payload.text };
+  if (payload.categoryId !== undefined)
+    body["category_id"] = payload.categoryId;
+  if (payload.completed !== undefined) body["completed"] = payload.completed;
+  const res = await api.post<EntityResponse>("/todos", body);
+  return toTodo(res.data);
+}
+
+export async function updateTodo(
+  id: string,
+  payload: { text?: string; categoryId?: string; completed?: boolean },
+): Promise<Todo> {
+  const body: Record<string, unknown> = {};
+  if (payload.text !== undefined) body["text"] = payload.text;
+  if (payload.categoryId !== undefined)
+    body["category_id"] = payload.categoryId;
+  if (payload.completed !== undefined) body["completed"] = payload.completed;
+  const res = await api.patch<EntityResponse>(`/todos/${id}`, body);
+  return toTodo(res.data);
+}
+
+export async function deleteTodo(id: string): Promise<void> {
+  await api.delete(`/todos/${id}`);
+}

--- a/frontend/src/components/CategoriesPage.tsx
+++ b/frontend/src/components/CategoriesPage.tsx
@@ -62,7 +62,8 @@ export const CategoriesPage = () => {
     setSnackbar((prev) => ({ ...prev, open: false }));
   };
 
-  const formatDate = (date: Date | string) => {
+  const formatDate = (date?: Date | string) => {
+    if (!date) return "-";
     const dateObj = date instanceof Date ? date : new Date(date);
     return new Intl.DateTimeFormat("ja-JP", {
       year: "numeric",

--- a/frontend/src/components/CategoriesPage.tsx
+++ b/frontend/src/components/CategoriesPage.tsx
@@ -13,13 +13,15 @@ import {
   Stack,
   Snackbar,
   Alert,
+  CircularProgress,
 } from "@mui/material";
 import { Edit as EditIcon, Delete as DeleteIcon } from "@mui/icons-material";
 import { useCategoryManagement } from "../hooks/useCategoryManagement";
 
 export const CategoriesPage = () => {
   const navigate = useNavigate();
-  const { categories, deleteCategory } = useCategoryManagement();
+  const { categories, deleteCategory, loading, error, offline } =
+    useCategoryManagement();
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: string;
@@ -93,7 +95,29 @@ export const CategoriesPage = () => {
           </Button>
         </Box>
 
-        {categories.length === 0 ? (
+        {offline && (
+          <Box my={2}>
+            <Alert severity="warning" data-testid="categories-offline">
+              オフラインです。操作は一時的に保存されない場合があります。
+            </Alert>
+          </Box>
+        )}
+
+        {error && (
+          <Box my={2}>
+            <Alert severity="error" data-testid="categories-error">
+              {error}
+            </Alert>
+          </Box>
+        )}
+
+        {loading && (
+          <Box display="flex" justifyContent="center" my={4}>
+            <CircularProgress data-testid="categories-loading" />
+          </Box>
+        )}
+
+        {!loading && categories.length === 0 ? (
           <Typography
             variant="body1"
             color="text.secondary"
@@ -102,7 +126,7 @@ export const CategoriesPage = () => {
           >
             カテゴリがありません
           </Typography>
-        ) : (
+        ) : !loading ? (
           <List>
             {categories.map((category) => (
               <ListItem
@@ -162,7 +186,7 @@ export const CategoriesPage = () => {
               </ListItem>
             ))}
           </List>
-        )}
+        ) : null}
       </Paper>
 
       <Snackbar

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -194,6 +194,7 @@ export const FilterBar = ({
           <FormControlLabel
             control={
               <Switch
+                role="switch"
                 checked={filters.tagCondition === "all"}
                 onChange={handleTagConditionChange}
                 size="small"

--- a/frontend/src/components/TodoApp.tsx
+++ b/frontend/src/components/TodoApp.tsx
@@ -30,6 +30,10 @@ export const TodoApp = () => {
   const [rawTodos, setRawTodos] = useState<Todo[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [offline, setOffline] = useState<boolean>(() => {
+    if (typeof navigator === "undefined") return false;
+    return navigator.onLine === false;
+  });
 
   // APIから取得したTodoを正規化（tags/orderが欠けている可能性に対応）
   const todos = useMemo(
@@ -72,6 +76,22 @@ export const TodoApp = () => {
     })();
     return () => {
       mounted = false;
+    };
+  }, []);
+
+  // オンライン/オフライン検知
+  useEffect(() => {
+    const handleOnline = () => setOffline(false);
+    const handleOffline = () => setOffline(true);
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", handleOnline);
+      window.addEventListener("offline", handleOffline);
+    }
+    return () => {
+      if (typeof window !== "undefined") {
+        window.removeEventListener("online", handleOnline);
+        window.removeEventListener("offline", handleOffline);
+      }
     };
   }, []);
   const { categories } = useCategoryManagement();
@@ -196,6 +216,14 @@ export const TodoApp = () => {
         <Typography variant="h3" component="h1" color="primary" sx={{ mb: 2 }}>
           Todo App
         </Typography>
+
+        {offline && (
+          <Box my={2}>
+            <Alert severity="warning">
+              オフラインです。操作は一時的に保存されない場合があります。
+            </Alert>
+          </Box>
+        )}
 
         {loading && (
           <Box display="flex" justifyContent="center" my={4}>

--- a/frontend/src/components/TodoEditForm.tsx
+++ b/frontend/src/components/TodoEditForm.tsx
@@ -75,6 +75,7 @@ export const TodoEditForm = ({
         {/* テキスト入力 */}
         <TextField
           inputRef={textInputRef}
+          inputProps={{ "data-testid": "todoedit-text" }}
           fullWidth
           variant="outlined"
           size="small"
@@ -93,6 +94,7 @@ export const TodoEditForm = ({
             <InputLabel id="edit-category-select-label">カテゴリ</InputLabel>
             <Select
               labelId="edit-category-select-label"
+              data-testid="todoedit-category"
               value={editData.categoryId || ""}
               label="カテゴリ"
               onChange={handleCategoryChange}
@@ -114,6 +116,7 @@ export const TodoEditForm = ({
             variant="outlined"
             label="タグ"
             placeholder="タグをカンマ区切りで入力"
+            inputProps={{ "data-testid": "todoedit-tags" }}
             value={tagsInputValue}
             onChange={handleTagsChange}
             sx={{ flex: 1 }}

--- a/frontend/src/components/TodoForm.tsx
+++ b/frontend/src/components/TodoForm.tsx
@@ -79,6 +79,7 @@ export const TodoForm = ({ onSubmit, categories }: TodoFormProps) => {
             <InputLabel id="category-select-label">カテゴリ</InputLabel>
             <Select
               labelId="category-select-label"
+              data-testid="todoform-category"
               value={categoryId}
               label="カテゴリ"
               onChange={handleCategoryChange}
@@ -100,6 +101,7 @@ export const TodoForm = ({ onSubmit, categories }: TodoFormProps) => {
             variant="outlined"
             label="タグ"
             placeholder="タグをカンマ区切りで入力"
+            inputProps={{ "data-testid": "todoform-tags" }}
             value={tagsInput}
             onChange={(e) => setTagsInput(e.target.value)}
             helperText="例: 重要, 急ぎ, 今日中"

--- a/frontend/src/components/TodoItem.tsx
+++ b/frontend/src/components/TodoItem.tsx
@@ -91,6 +91,11 @@ export const TodoItem = ({
             checked={todo.completed}
             tabIndex={-1}
             disableRipple
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle(todo.id);
+            }}
+            onChange={() => onToggle(todo.id)}
           />
         </ListItemIcon>
         <ListItemText

--- a/frontend/src/components/TodoItem.tsx
+++ b/frontend/src/components/TodoItem.tsx
@@ -92,8 +92,8 @@ export const TodoItem = ({
             tabIndex={-1}
             disableRipple
             onClick={(e) => {
+              // ListItemButton へのバブリングを防止
               e.stopPropagation();
-              onToggle(todo.id);
             }}
             onChange={() => onToggle(todo.id)}
           />

--- a/frontend/src/hooks/useTodoSorting.ts
+++ b/frontend/src/hooks/useTodoSorting.ts
@@ -17,7 +17,7 @@ export const useTodoSorting = (
   onReorder?: (reorderedTodos: Todo[]) => void,
 ): UseTodoSortingReturn => {
   const sortedTodos = useMemo(() => {
-    return [...todos].sort((a, b) => a.order - b.order);
+    return [...todos].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   }, [todos]);
 
   const handleDragEnd = useCallback(
@@ -79,7 +79,7 @@ export const useTodoSorting = (
           break;
         case "custom":
         default:
-          sorted = [...todos].sort((a, b) => a.order - b.order);
+          sorted = [...todos].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
           break;
       }
 

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -19,4 +19,8 @@ export interface UseCategoryManagementReturn {
   updateCategory: (id: string, data: CategoryFormData) => void;
   deleteCategory: (id: string) => boolean;
   isCategoryInUse: (id: string) => boolean;
+  // UI/UX改善: 追加情報（任意）
+  loading?: boolean;
+  error?: string | null;
+  offline?: boolean;
 }

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -3,8 +3,8 @@ export interface Category {
   name: string;
   color: string;
   description?: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 export interface CategoryFormData {

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -5,7 +5,7 @@ export interface Todo {
   createdAt: Date;
   categoryId?: string;
   tags: string[];
-  order: number;
+  order?: number;
 }
 
 export interface EditTodoData {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
概要
- フロントエンドのデータ管理をLocalStorageからRails API連携へ移行しました。
- APIクライアント、Todo/CategoryのAPIラッパー、UIのローディング/エラー/オフライン対応、楽観的更新、テスト更新を含みます。

変更点
- API通信基盤
  - `frontend/src/api/client.ts` を追加/拡張（GET/POST/PATCH/DELETE、標準ヘッダー、詳細なエラーハンドリング、`VITE_API_BASE_URL`対応）
- Todo機能
  - `frontend/src/api/todos.ts` で一覧/作成/更新/削除をAPI化（snake_case→camelCase、Date変換）
  - `frontend/src/components/TodoApp.tsx` で初期取得・追加・更新・削除のAPI連携と楽観的更新、ローディング/エラー/オフライン表示
- Category機能
  - `frontend/src/api/categories.ts` で一覧/作成/更新/削除をAPI化（Date変換）
  - `frontend/src/hooks/useCategoryManagement.ts` で初回ロード時にAPI結果を反映（ユーザー操作前に上書き）。作成/更新/削除をAPI連携＋楽観的更新
  - `frontend/src/components/CategoriesPage.tsx` でローディング/エラー/オフライン表示
- テスト（TDD）
  - Vitest: `frontend/__tests__/utils/{todosApi,categoriesApi}.test.ts` を追加、fetchモックでI/Fと変換を検証
  - Playwright E2E: `frontend/__tests__/e2e/ui-ux.spec.ts` を追加（ローディング/エラー/オフライン表示を検証）、APIモックユーティリティ `frontend/__tests__/e2e/utils/mockApi.ts`
- ドキュメント
  - `Docker.md` の補足修正

背景・目的
- Issue #25 の要件に基づくLocalStorageからAPI連携への完全移行。

注意点
- `useCategoryManagement` の `isCategoryInUse` は現状モックです。厳密な判定が必要であればAPI拡張を検討してください。

関連Issue
- Closes #25

実行手順（Docker）
- 起動: `docker compose up -d`
- 単体テスト（Vitest）: `docker compose exec frontend npm run test:run`
- E2E（ローカル）: `npm run test:e2e` / `npm run test:e2e:ui`（要アプリ起動）
