### PR TITLE
 UI: FilterBarをTodoForm直下へ移動（一覧の上に表示）

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -220,6 +220,9 @@ docker compose exec frontend npm run test:run
 
 # ウォッチモードでテスト実行
 docker compose exec frontend npm run test
+
+# 特定のテストファイルだけを実行（例）
+docker compose exec frontend npm run test:run -- __tests__/components/TodoApp.test.tsx
 ```
 
 #### E2Eテスト（End-to-End Tests）

--- a/frontend/src/components/TodoApp.tsx
+++ b/frontend/src/components/TodoApp.tsx
@@ -242,6 +242,16 @@ export const TodoApp = () => {
 
         <TodoForm onSubmit={handleAddTodo} categories={categories} />
 
+        {/* FilterBar を一覧の上（フォーム直下）に移動 */}
+        <FilterBar
+          filters={filters}
+          onFiltersChange={updateFilters}
+          onReset={resetFilters}
+          categories={categories}
+          availableTags={availableTags}
+          activeFilterCount={activeFilterCount}
+        />
+
         {displayTodos.length > 0 && (
           <Paper elevation={2} sx={{ mt: 2 }}>
             <DndContext
@@ -290,15 +300,6 @@ export const TodoApp = () => {
             No todos match the current filters.
           </Typography>
         )}
-
-        <FilterBar
-          filters={filters}
-          onFiltersChange={updateFilters}
-          onReset={resetFilters}
-          categories={categories}
-          availableTags={availableTags}
-          activeFilterCount={activeFilterCount}
-        />
       </Paper>
     </Box>
   );


### PR DESCRIPTION
概要: FilterBarをTodoForm直下に移動し、一覧より上に表示
変更点: frontend/src/components/TodoApp.tsx のレンダリング順のみ変更
背景・目的: 一覧閲覧前に条件設定しやすいUIにするため
確認項目: 既存機能の回帰なし、対象ファイルのLint/Format OK
関連: Close #34