### PR TITLE
feat: カテゴリ楽観更新の失敗ハンドリングを強化

### DIFF
--- a/frontend/__tests__/e2e/categories-error.spec.ts
+++ b/frontend/__tests__/e2e/categories-error.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+import { setupApiMock } from "./utils/mockApi";
+
+test.describe("Categories Error Handling", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMock(page);
+  });
+
+  // 概要: カテゴリ削除失敗時にUIがロールバックされることをテスト
+  // 目的: 削除API失敗時にカテゴリ一覧が復元され、エラーメッセージが表示されることを保証
+  test("should restore category and show error snackbar when delete fails", async ({
+    page,
+  }) => {
+    await page.route("**/api/categories/private", async (route) => {
+      if (route.request().method() === "DELETE") {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "server" }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    page.on("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+
+    await page.goto("/categories");
+
+    const privateRow = page
+      .locator("li")
+      .filter({ hasText: "プライベート" })
+      .first();
+    await expect(privateRow).toBeVisible();
+
+    const deleteButton = privateRow.getByRole("button", { name: "削除" });
+    await deleteButton.click();
+
+    const errorMessage = "カテゴリの削除に失敗しました。再試行してください。";
+    const snackbarAlert = page
+      .locator('.MuiSnackbar-root [role="alert"]')
+      .filter({ hasText: errorMessage })
+      .first();
+
+    await expect(snackbarAlert).toBeVisible();
+    await expect(page.getByTestId("categories-error")).toContainText(
+      errorMessage,
+    );
+    await expect(privateRow).toBeVisible();
+  });
+});

--- a/frontend/src/hooks/useCategoryManagement.ts
+++ b/frontend/src/hooks/useCategoryManagement.ts
@@ -41,6 +41,12 @@ const DEFAULT_CATEGORIES: Category[] = [
   },
 ];
 
+const CATEGORY_ERROR_MESSAGES = {
+  create: "カテゴリの作成に失敗しました。再試行してください。",
+  update: "カテゴリの更新に失敗しました。再試行してください。",
+  delete: "カテゴリの削除に失敗しました。再試行してください。",
+} as const;
+
 export const useCategoryManagement = (): UseCategoryManagementReturn => {
   // 初期表示は従来通りのデフォルトカテゴリを使い、マウント後にAPI結果で上書き
   const [categories, setCategories] = useState<Category[]>(DEFAULT_CATEGORIES);
@@ -108,11 +114,12 @@ export const useCategoryManagement = (): UseCategoryManagementReturn => {
   const createCategory = useCallback(
     (data: CategoryFormData) => {
       interactedRef.current = true;
+      setError(null);
       // 同じ名前のカテゴリが既に存在するかチェック
       const exists = categories.some((category) => category.name === data.name);
       if (exists) return;
 
-      // 楽観的に即時追加
+      // 楽観的に即時追加し、ロールバック用にtempIdを保持
       const tempId = `temp-cat-${Date.now()}`;
       const optimistic: Category = {
         id: tempId,
@@ -139,53 +146,70 @@ export const useCategoryManagement = (): UseCategoryManagementReturn => {
                 : c,
             ),
           );
+          setError(null);
         } catch {
-          // 失敗時はロールバック
+          // 失敗時は楽観的に追加したカテゴリを除去
           setCategories((prev) => prev.filter((c) => c.id !== tempId));
+          setError(CATEGORY_ERROR_MESSAGES.create);
         }
       })();
     },
     [categories],
   );
 
-  const updateCategory = useCallback((id: string, data: CategoryFormData) => {
-    interactedRef.current = true;
-    // 楽観的更新（今後のエラーUIで巻き戻し対応予定）
-    setCategories((prev) =>
-      prev.map((category) =>
-        category.id === id
-          ? {
-              ...category,
-              name: data.name,
-              color: data.color,
-              description: data.description,
-              updatedAt: new Date(),
-            }
-          : category,
-      ),
-    );
+  const updateCategory = useCallback(
+    (id: string, data: CategoryFormData) => {
+      interactedRef.current = true;
+      setError(null);
 
-    (async () => {
-      try {
-        const updated = await apiUpdateCategory(id, { name: data.name });
-        if (updated) {
+      const original = categories.find((category) => category.id === id);
+      if (!original) return;
+
+      const originalClone: Category = { ...original };
+
+      // 楽観的更新
+      setCategories((prev) =>
+        prev.map((category) =>
+          category.id === id
+            ? {
+                ...category,
+                name: data.name,
+                color: data.color,
+                description: data.description,
+                updatedAt: new Date(),
+              }
+            : category,
+        ),
+      );
+
+      (async () => {
+        try {
+          const updated = await apiUpdateCategory(id, { name: data.name });
+          if (updated) {
+            setCategories((prev) =>
+              prev.map((c) =>
+                c.id === id
+                  ? {
+                      ...c,
+                      name: updated.name,
+                      // APIからはcolor/descriptionは来ないため、現在の値を維持
+                    }
+                  : c,
+              ),
+            );
+            setError(null);
+          }
+        } catch {
+          // 失敗時は元の状態へロールバック
           setCategories((prev) =>
-            prev.map((c) =>
-              c.id === id
-                ? {
-                    ...c,
-                    name: updated.name,
-                    // APIからはcolor/descriptionは来ないため、現在の値を維持
-                  }
-                : c,
-            ),
+            prev.map((c) => (c.id === id ? originalClone : c)),
           );
+          setError(CATEGORY_ERROR_MESSAGES.update);
         }
-      } catch {
-        // 失敗時の巻き戻しは今後のUI改善で対応
-      }
-    })();
-  }, []);
+      })();
+    },
+    [categories],
+  );
 
   const isCategoryInUse = useCallback(async (id: string): Promise<boolean> => {
     usageErrorRef.current = false;
@@ -210,13 +234,30 @@ export const useCategoryManagement = (): UseCategoryManagementReturn => {
       if (usageErrorRef.current) return { status: "usageCheckFailed" };
       if (inUse) return { status: "inUse" };
 
+      setError(null);
+
+      const targetIndex = categories.findIndex(
+        (category) => category.id === id,
+      );
+      if (targetIndex === -1) return { status: "notFound" };
+      const targetCategory = { ...categories[targetIndex] };
+
+      // 楽観的削除
+      setCategories((prev) => prev.filter((category) => category.id !== id));
+
       try {
         await apiDeleteCategory(id);
-        setCategories((prev) => prev.filter((category) => category.id !== id));
         setError(null);
         return { status: "success" };
       } catch {
-        const message = "カテゴリの削除に失敗しました。再試行してください。";
+        const message = CATEGORY_ERROR_MESSAGES.delete;
+        setCategories((prev) => {
+          const exists = prev.some((category) => category.id === id);
+          if (exists) return prev;
+          const next = [...prev];
+          next.splice(targetIndex, 0, targetCategory);
+          return next;
+        });
         setError(message);
         return { status: "error", message };
       }


### PR DESCRIPTION
## 概要
- カテゴリ作成・更新・削除時の失敗ハンドリングを強化し、UI状態とエラーメッセージを統一しました
- 失敗系ユニットテストとコンポーネントテストを追加し、挙動をTDDで検証しました
- Playwrightで削除失敗シナリオのE2Eテストを追加してUIロールバックを確認しました

## 変更点
- `useCategoryManagement` にロールバック用スナップショットとエラーメッセージ定義を実装
- `CategoriesPage` のテストを拡張し、Alert/Snackbarの表示分岐を検証
- `categories-error.spec.ts` を新規作成して削除失敗時の振る舞いをE2Eで確認

## テスト
- `docker compose exec frontend npm run test:run -- __tests__/hooks/useCategoryManagement.test.ts`
- `docker compose exec frontend npm run test:run -- __tests__/components/CategoriesPage.test.tsx`
- `npm run test:e2e -- --project=chromium __tests__/e2e/categories-error.spec.ts`
- `npm run test:e2e`
- `docker compose exec frontend npm run lint`
- `docker compose exec frontend npm run format`
- `docker compose exec frontend npm run format:check`

Closes #38